### PR TITLE
Projection fixes for canted displays on OpenXR (like Valve Index)

### DIFF
--- a/src/openxr_manager.cpp
+++ b/src/openxr_manager.cpp
@@ -390,13 +390,7 @@ static XrFovf ApplyForcedProjectionFov(const XrFovf& sourceFov, float width, flo
         return sourceFov;
     }
 
-    float aspect = 1.0f;
-    if (width > 1.0f && height > 1.0f) {
-        aspect = width / height;
-    }
-    if (aspect < 0.01f) {
-        aspect = 1.0f;
-    }
+    const float aspect = 1.0f; //tells OpenXR vertical FOV matches horizontal. Prevends vertical camera stretching.
 
     const float halfFovH = (forceFov * 3.1415926535f / 180.0f) * 0.5f;
     const float halfFovV = atanf(tanf(halfFovH) / aspect);

--- a/src/openxr_manager.cpp
+++ b/src/openxr_manager.cpp
@@ -3286,6 +3286,7 @@ void OpenXRManager::Shutdown() {
     m_eyeSwapchains.clear();
     m_views.clear();
     m_viewConfigViews.clear();
+    m_runtimeIsSteamVR.store(false, std::memory_order_relaxed);
 
     if (m_fenceEvent) {
         CloseHandle(m_fenceEvent);

--- a/src/openxr_manager.cpp
+++ b/src/openxr_manager.cpp
@@ -1484,6 +1484,7 @@ bool OpenXRManager::Init() {
         if (GetXrRuntimeMode() == 1 && strcmp(ClassifyOpenXRRuntime(instanceProps.runtimeName), "SteamVR") != 0) {
             Log("OpenXRManager: xr_runtime=1 requested SteamVR, but the active runtime identified as %s.\n", ClassifyOpenXRRuntime(instanceProps.runtimeName));
         }
+        m_runtimeIsSteamVR.store(strcmp(ClassifyOpenXRRuntime(instanceProps.runtimeName), "SteamVR") == 0, std::memory_order_relaxed);
     }
 
     XrSystemGetInfo systemInfo{XR_TYPE_SYSTEM_GET_INFO};
@@ -2003,6 +2004,10 @@ DWORD OpenXRManager::FrameThreadMain() {
                             sourceEye = eye ^ 1;
                         }
 
+                        if (m_runtimeIsSteamVR.load(std::memory_order_relaxed)) {
+                            sourceEye = sourceEye ^ 1;
+                        }
+
                         uint32_t imageIndex = 0;
                         XrSwapchainImageAcquireInfo acquireInfo{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
                         const XrResult acquireRes = xrAcquireSwapchainImage(m_eyeSwapchains[eye].handle, &acquireInfo, &imageIndex);
@@ -2056,7 +2061,7 @@ DWORD OpenXRManager::FrameThreadMain() {
                         // the rendered image or the runtime reprojects it the wrong way
                         // (tearing / wobble). For debugEye source overrides, follow the
                         // SOURCE eye's pose so the image+pose pair stays matched.
-                        const uint32_t poseEye = (debugEye == 1 || debugEye == 2 || debugEye == 3) ? sourceEye : eye;
+                        const uint32_t poseEye = sourceEye;
                         if (poseEye < 2) {
                             projectionViews[eye].pose = eyePoses[poseEye];
                             projectionViews[eye].fov = eyeFovs[poseEye];

--- a/src/openxr_manager.cpp
+++ b/src/openxr_manager.cpp
@@ -1481,7 +1481,6 @@ bool OpenXRManager::Init() {
         if (GetXrRuntimeMode() == 1 && strcmp(ClassifyOpenXRRuntime(instanceProps.runtimeName), "SteamVR") != 0) {
             Log("OpenXRManager: xr_runtime=1 requested SteamVR, but the active runtime identified as %s.\n", ClassifyOpenXRRuntime(instanceProps.runtimeName));
         }
-        m_runtimeIsSteamVR.store(strcmp(ClassifyOpenXRRuntime(instanceProps.runtimeName), "SteamVR") == 0, std::memory_order_relaxed);
     }
 
     XrSystemGetInfo systemInfo{XR_TYPE_SYSTEM_GET_INFO};
@@ -3287,7 +3286,6 @@ void OpenXRManager::Shutdown() {
     m_eyeSwapchains.clear();
     m_views.clear();
     m_viewConfigViews.clear();
-    m_runtimeIsSteamVR.store(false, std::memory_order_relaxed);
 
     if (m_fenceEvent) {
         CloseHandle(m_fenceEvent);

--- a/src/openxr_manager.cpp
+++ b/src/openxr_manager.cpp
@@ -382,7 +382,10 @@ static int64_t PickMonoSwapchainFormat(const std::vector<int64_t>& runtimeFormat
 }
 
 static XrFovf ApplyForcedProjectionFov(const XrFovf& sourceFov, float width, float height) {
-    const float forceFov = GetForcedFov();
+    float forceFov = GetForcedFov();
+    if (forceFov <= 1.0f || forceFov >= 170.0f) {
+        forceFov = OpenXRManager::Get().GetRuntimeHorizontalFovDeg();
+    }
     if (forceFov <= 1.0f || forceFov >= 170.0f) {
         return sourceFov;
     }
@@ -2004,10 +2007,6 @@ DWORD OpenXRManager::FrameThreadMain() {
                             sourceEye = eye ^ 1;
                         }
 
-                        if (m_runtimeIsSteamVR.load(std::memory_order_relaxed)) {
-                            sourceEye = sourceEye ^ 1;
-                        }
-
                         uint32_t imageIndex = 0;
                         XrSwapchainImageAcquireInfo acquireInfo{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
                         const XrResult acquireRes = xrAcquireSwapchainImage(m_eyeSwapchains[eye].handle, &acquireInfo, &imageIndex);
@@ -2061,7 +2060,7 @@ DWORD OpenXRManager::FrameThreadMain() {
                         // the rendered image or the runtime reprojects it the wrong way
                         // (tearing / wobble). For debugEye source overrides, follow the
                         // SOURCE eye's pose so the image+pose pair stays matched.
-                        const uint32_t poseEye = sourceEye;
+                        const uint32_t poseEye = (debugEye == 1 || debugEye == 2 || debugEye == 3) ? sourceEye : eye;
                         if (poseEye < 2) {
                             projectionViews[eye].pose = eyePoses[poseEye];
                             projectionViews[eye].fov = eyeFovs[poseEye];

--- a/src/openxr_manager.h
+++ b/src/openxr_manager.h
@@ -54,6 +54,7 @@ public:
 
     bool IsInitialized() const { return m_initialized; }
     bool IsSessionRunning() const { return m_sessionRunning.load(std::memory_order_relaxed); }
+    bool IsRuntimeSteamVR() const { return m_runtimeIsSteamVR.load(std::memory_order_relaxed); }
 
 private:
     static DWORD WINAPI FrameThreadThunk(LPVOID param);

--- a/src/openxr_manager.h
+++ b/src/openxr_manager.h
@@ -181,6 +181,7 @@ private:
     std::atomic<float> m_runtimeHorizontalFovDeg = 0.0f;
     std::atomic<float> m_runtimeVerticalFovDeg = 0.0f;
     std::atomic<float> m_runtimeIpd = 0.0f;
+    std::atomic<bool> m_runtimeIsSteamVR = false;
     // Head velocity in the base-recentered frame (rad/s, m/s) for AER forward pose
     // prediction. Sampled from xrLocateSpace and consumed by GetHeadPose().
     std::atomic<bool> m_velValid = false;

--- a/src/openxr_manager.h
+++ b/src/openxr_manager.h
@@ -54,7 +54,6 @@ public:
 
     bool IsInitialized() const { return m_initialized; }
     bool IsSessionRunning() const { return m_sessionRunning.load(std::memory_order_relaxed); }
-    bool IsRuntimeSteamVR() const { return m_runtimeIsSteamVR.load(std::memory_order_relaxed); }
 
 private:
     static DWORD WINAPI FrameThreadThunk(LPVOID param);
@@ -182,7 +181,6 @@ private:
     std::atomic<float> m_runtimeHorizontalFovDeg = 0.0f;
     std::atomic<float> m_runtimeVerticalFovDeg = 0.0f;
     std::atomic<float> m_runtimeIpd = 0.0f;
-    std::atomic<bool> m_runtimeIsSteamVR = false;
     // Head velocity in the base-recentered frame (rad/s, m/s) for AER forward pose
     // prediction. Sampled from xrLocateSpace and consumed by GetHeadPose().
     std::atomic<bool> m_velValid = false;


### PR DESCRIPTION
Support for canted displays such as the Valve Index via OpenXR FOV patches.

* Prevent asymmetrical FOV from forceFov

* Lock projection ratio to 1.0, same as forced vertical FOV