### PR TITLE
Fix the black border on canted headsets (Quest 3, Pimax)

### DIFF
--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -4629,6 +4629,10 @@ extern "C" void __fastcall OnNormalFovHookCallback(void* cameraState, float orig
     constexpr float kD2R = 3.1415926535f / 180.0f;
     const float forced = GetForcedFov();
 
+    const float aspect = (g_launcherWidth > 1 && g_launcherHeight > 1)
+        ? (static_cast<float>(g_launcherWidth) / static_cast<float>(g_launcherHeight))
+        : 1.0f;
+
     float targetHDeg = 0.0f;
     if (forced > 1.0f && forced < 170.0f) {
         targetHDeg = forced;                      // xr_force_fov has always meant the horizontal
@@ -4636,18 +4640,17 @@ extern "C" void __fastcall OnNormalFovHookCallback(void* cameraState, float orig
         XrFovf lf{}, rf{};
         if (OpenXRManager::Get().GetCurrentEyeFov(0, &lf) &&
             OpenXRManager::Get().GetCurrentEyeFov(1, &rf)) {
-            // The same de-canting the submit layer applies, so the two cannot drift apart.
-            const RuntimeFovCorrection corr = ComputeRuntimeFovCorrection(lf, rf);
-            targetHDeg = GetCorrectedGameHorizontalFovDeg(corr);
+            // Size to COVER the panel, not to match its span. The submit layer recentres the frustum
+            // on the eye axis but never rotates the pose to match it, so on a canted headset a
+            // span-sized frustum leaves the outer edge and the bottom black. See
+            // GetPanelCoveringHorizontalFovDeg for the geometry. The submit follows this value
+            // through GetGameRenderFovDeg, so the two ends of the contract cannot drift apart.
+            targetHDeg = GetPanelCoveringHorizontalFovDeg(lf, rf, aspect);
         }
         if (!(targetHDeg > 1.0f && targetHDeg < 170.0f)) {
             targetHDeg = OpenXRManager::Get().GetRuntimeHorizontalFovDeg();
         }
     }
-
-    const float aspect = (g_launcherWidth > 1 && g_launcherHeight > 1)
-        ? (static_cast<float>(g_launcherWidth) / static_cast<float>(g_launcherHeight))
-        : 1.0f;
 
     float verticalDeg = originalFov;
     float horizontalDeg = 0.0f;

--- a/src/vr/openxr/openxr_manager.cpp
+++ b/src/vr/openxr/openxr_manager.cpp
@@ -293,7 +293,16 @@ static void LogDxgiAdapterForDevice(ID3D12Device* device) {
 void OpenXRManager::MaybeLogRuntimeFovDetails(const XrFovf& left, const XrFovf& right, float runtimeHfovDeg, float runtimeVfovDeg, float runtimeIpdMeters) {
     const float forcedProjectionFovDeg = GetForcedFov();
     const RuntimeFovCorrection corr = ComputeRuntimeFovCorrection(left, right);
-    const float correctedGameHfovDeg = GetCorrectedGameHorizontalFovDeg(corr);
+    // NOT the FOV the game renders -- see the field name in the log line below.
+    //
+    // This is the de-canted SPAN (both eyes recentred onto their own axis and averaged), which is
+    // what the runtime branch used to render before it started sizing to cover the panel. On a
+    // canted headset the two now differ by the whole cant -- 94 here against 108 rendered on a
+    // Quest 3 -- so logging it as "correctedGameHFov" sent the next reader looking for a bug in
+    // the render path. Kept because it is still the right number for judging how canted a headset
+    // is (span vs cover is exactly the widening the cant forces), renamed because it is not the
+    // render FOV. That one is on the NormalFOV line as targetH.
+    const float deCantedHfovDeg = GetCorrectedGameHorizontalFovDeg(corr);
 
     auto valueChanged = [](float a, float b) {
         return fabsf(a - b) > 0.01f;
@@ -324,7 +333,7 @@ void OpenXRManager::MaybeLogRuntimeFovDetails(const XrFovf& left, const XrFovf& 
     m_loggedRuntimeIpd = runtimeIpdMeters;
     m_loggedForcedProjectionFovDeg = forcedProjectionFovDeg;
 
-    Log("OpenXRManager[FOV]: raw left=(L=%.3f R=%.3f U=%.3f D=%.3f) right=(L=%.3f R=%.3f U=%.3f D=%.3f) runtimeHFov=%.3f runtimeVFov=%.3f runtimeIPD=%.4f correctedGameHFov=%.3f correctionYaw=%.3f correctionPitch=%.3f xr_force_fov=%.3f useRuntimeProjection=%d\n",
+    Log("OpenXRManager[FOV]: raw left=(L=%.3f R=%.3f U=%.3f D=%.3f) right=(L=%.3f R=%.3f U=%.3f D=%.3f) runtimeHFov=%.3f runtimeVFov=%.3f runtimeIPD=%.4f deCantedHFov=%.3f correctionYaw=%.3f correctionPitch=%.3f xr_force_fov=%.3f useRuntimeProjection=%d\n",
         left.angleLeft * (180.0f / 3.1415926535f),
         left.angleRight * (180.0f / 3.1415926535f),
         left.angleUp * (180.0f / 3.1415926535f),
@@ -336,7 +345,7 @@ void OpenXRManager::MaybeLogRuntimeFovDetails(const XrFovf& left, const XrFovf& 
         runtimeHfovDeg,
         runtimeVfovDeg,
         runtimeIpdMeters,
-        correctedGameHfovDeg,
+        deCantedHfovDeg,
         corr.yawDeltaRad * (180.0f / 3.1415926535f),
         corr.pitchDeltaRad * (180.0f / 3.1415926535f),
         forcedProjectionFovDeg,

--- a/src/vr/openxr/runtime_fov_correction.h
+++ b/src/vr/openxr/runtime_fov_correction.h
@@ -60,3 +60,54 @@ inline float GetCorrectedGameHorizontalFovDeg(const RuntimeFovCorrection& corr) 
     const float h1 = corr.eye[1].angleRight - corr.eye[1].angleLeft;
     return ((h0 + h1) * 0.5f) * (180.0f / 3.1415926535f);
 }
+
+// The panel's largest half-angle on each axis, taken across BOTH eyes: the engine renders one FOV
+// scalar for both views, so a frustum that covers has to cover the worse eye.
+inline void GetPanelHalfAngles(const XrFovf& left, const XrFovf& right, float* halfH, float* halfV) {
+    *halfH = std::fmax(
+        std::fmax(std::fabs(left.angleLeft), std::fabs(left.angleRight)),
+        std::fmax(std::fabs(right.angleLeft), std::fabs(right.angleRight)));
+    *halfV = std::fmax(
+        std::fmax(std::fabs(left.angleUp), std::fabs(left.angleDown)),
+        std::fmax(std::fabs(right.angleUp), std::fabs(right.angleDown)));
+}
+
+// COVER THE PANEL, DON'T MATCH ITS SPAN.
+//
+// The engine renders ONE frustum, symmetric about the camera axis, and derives the vertical from the
+// render target's aspect -- there is no off-axis/shear term to give it. A canted headset's panel is
+// not symmetric about the eye axis: a Quest 3 reports -54/+40 horizontally and +44/-55 vertically,
+// i.e. frusta rotated 7 deg outward and 5.5 deg down. ComputeRuntimeFovCorrection recentres the
+// FRUSTUM onto the eye axis, but nothing rotates the POSE to match, so a frustum sized to the
+// panel's SPAN (2 x 47 deg) sits 7 deg short of the outer edge and 5 deg short of the bottom. Those
+// gaps are the black border, and the matching slivers on the inner edge and top are rendered and
+// thrown away.
+//
+// Sizing to the panel's largest HALF-angle instead covers every edge. The inner slice still falls
+// outside the panel and is never shown -- that is the cost, and it is proportional to the cant, so a
+// symmetric headset pays nothing. R.E.A.L. VR reaches the same place from the other end: it renders
+// wider than the panel and crops the submitted rectangle.
+//
+// The vertical is not free to choose -- the engine derives V from H through the render aspect -- so H
+// has to satisfy the vertical requirement as well, which is the second term below.
+//
+// Takes the max across BOTH eyes because the engine renders a single FOV scalar for both views. On a
+// symmetric headset the largest half-angle IS half the span, so this returns exactly what
+// GetCorrectedGameHorizontalFovDeg returns and nothing changes. Returns 0 when the inputs cannot
+// produce a sane frustum, so callers keep their existing fallback.
+inline float GetPanelCoveringHorizontalFovDeg(const XrFovf& left, const XrFovf& right, float aspect) {
+    if (!(aspect > 0.01f && aspect < 100.0f)) {
+        return 0.0f;
+    }
+
+    float halfH = 0.0f, halfV = 0.0f;
+    GetPanelHalfAngles(left, right, &halfH, &halfV);
+    if (!(halfH > 0.0f) || !(halfV > 0.0f)) {
+        return 0.0f;
+    }
+
+    // tan(H/2) = tan(V/2) * aspect, so the H that just reaches halfV is atan(tan(halfV) * aspect).
+    const float halfRad = std::fmax(halfH, std::atan(std::tan(halfV) * aspect));
+    const float deg = 2.0f * halfRad * (180.0f / 3.1415926535f);
+    return (deg > 1.0f && deg < 170.0f) ? deg : 0.0f;
+}


### PR DESCRIPTION
## The problem

With **"Use OpenXR runtime projection FOV"** checked I get a black band down the outer edge of each eye and along the bottom. Never at the top. Quest 3 + Virtual Desktop.

Dragging the FOV slider to ~100–102 makes it go away, but that's guessing, and it's a different number for every headset.

## Why it happens

Quest 3 lenses are angled outward, so the runtime reports an **off-axis** frustum per eye — mine is `-54/+40` horizontally, `+44/-55` vertically.

`ComputeRuntimeFovCorrection` recentres that onto a symmetric `±47`. It de-cants the **frustum** — but nothing ever rotates the **pose** to match. So we submit a frustum sitting 7° short of the outer edge and 5° short of the bottom, while rendering slivers on the inner edge and top that are thrown away.

That predicts exactly what I saw: nothing at the top, huge bands at FOV 80, gone by 100–102.

## The fix

The engine renders one frustum, symmetric about the camera axis, and derives the other axis from the render target's aspect — there's no shear term to hand it. So a symmetric frustum can cover an off-axis one in only two ways: **point it** or **widen it**.

Pointing means rotating the render camera, and `MAIN` is simultaneously the gameplay camera — rotating it drags interaction, scanner and lock-on along with it. So this widens: size the frustum to the panel's largest **half-angle** instead of half its **span**.

## What it costs

Pixel density, in proportion to how canted the headset is. **Nothing at all on a symmetric one** — I compiled the helper standalone and checked: Pico 4 `104 → 104`, Valve Index `100 → 100`, bit-identical. About 22% on a Quest 3.

That trade is deliberate: a visible black band is a defect, a few percent of sharpness is a setting. Getting the density back is a separate problem and I'd rather it were a separate PR than smuggled into this one.

## Tested

Quest 3, 9800X3D / 5090, on **both runtimes**:

- **Virtual Desktop (VDXR)** — border gone, world scale unchanged, reticle still lands where it should.
- **SteamVR** — same result.

Nothing is read from a per-headset or per-runtime table; the frusta come from the runtime each session, which is why both behave the same. The no-op-on-symmetric-frusta check was done before touching hardware.

## Known gaps

- Other canted headsets (Quest 2, Crystal, Dream Air) get the same widening and the same density cost. Milder — the Dream Air reports about 4° of asymmetry against the Quest 3's 7° — but untested, since I don't own them.
- I also renamed the `correctedGameHFov` log field to `deCantedHFov`. It was printing 94 while the engine rendered 108, which would send the next person straight down a wrong path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
