### PR TITLE
Fix VR controller input and add controller enhancements

### DIFF
--- a/mods/cet/CyberpunkVRPort_Holster/init.lua
+++ b/mods/cet/CyberpunkVRPort_Holster/init.lua
@@ -41,6 +41,26 @@ local rightGripPrev = 0
 local cooldown = 0.0
 local lastZone = nil
 
+local function getCurrentZone()
+    local dR = GetVRSharedSlot(20)
+    local dL = GetVRSharedSlot(21)
+    local dB = GetVRSharedSlot(22)
+    if dR < 0 then dR = 1e9 end
+    if dL < 0 then dL = 1e9 end
+    if dB < 0 then dB = 1e9 end
+
+    -- B needs a CLEAR win over the right hip: the shoulder anchor sits close to a
+    -- raised wrist, and a fuzzy B-vs-R call was swapping weapon slots 1<->2.
+    if dB < PROX_BACK and (dB + BACK_MARGIN) < math.min(dL, dR) then
+        return "B", dR, dL, dB
+    elseif dL < PROX_L and dL <= dR then
+        return "L", dR, dL, dB
+    elseif dR < PROX_R then
+        return "R", dR, dL, dB
+    end
+    return nil, dR, dL, dB
+end
+
 local function classify(name)
     local lc = name:lower()
     for _, kw in ipairs(MELEE_KW)  do if lc:find(kw, 1, true) then return "melee"  end end
@@ -78,15 +98,25 @@ registerForEvent('onUpdate', function(dt)
     cooldown = math.max(0.0, cooldown - dt)
 
     if type(GetVRSharedSlot) ~= 'function' then return end
+    local canPublishGripRoute = type(SetVRRightGripRoute) == 'function'
     local pl = Game.GetPlayer()
-    if not pl then return end
+    if not pl then
+        if canPublishGripRoute then SetVRRightGripRoute(0) end
+        return
+    end
 
     -- While a cigarette is in the hands it occupies the WeaponRight slot -- which this mod would
     -- read as a held weapon -- and the right grip is what puts the cig in the mouth. Both of those
     -- collide, so suspend every holster gesture until the cig is put away. pcall because
     -- VRSmokeHasCig only exists when the smoking mod is installed.
     local okSmoke, smoking = pcall(function() return pl:VRSmokeHasCig() end)
-    if okSmoke and smoking then return end
+    if okSmoke and smoking then
+        if canPublishGripRoute then SetVRRightGripRoute(2) end
+        return
+    end
+
+    local zone, dR, dL, dB = getCurrentZone()
+    if canPublishGripRoute then SetVRRightGripRoute(zone and 2 or 1) end
 
     sinceScan = sinceScan + dt
     if sinceScan >= 1.0 then sinceScan = 0.0; rescan(pl) end
@@ -96,24 +126,6 @@ registerForEvent('onUpdate', function(dt)
     rightGripPrev = g
     if not edge or cooldown > 0 then return end
 
-    local dR = GetVRSharedSlot(20)
-    local dL = GetVRSharedSlot(21)
-    local dB = GetVRSharedSlot(22)
-    if dR < 0 then dR = 1e9 end
-    if dL < 0 then dL = 1e9 end
-    if dB < 0 then dB = 1e9 end
-
-    -- Which body zone is the right hand reaching to? (shared by both modes)
-    -- B needs a CLEAR win over the right hip: the shoulder anchor sits close to a
-    -- raised wrist, and a fuzzy B-vs-R call was swapping weapon slots 1<->2.
-    local zone
-    if dB < PROX_BACK and (dB + BACK_MARGIN) < math.min(dL, dR) then
-        zone = "B"
-    elseif dL < PROX_L and dL <= dR then
-        zone = "L"
-    elseif dR < PROX_R then
-        zone = "R"
-    end
     if not zone then return end
 
     -- Reliable "is a weapon in the right hand": read the WeaponRight slot directly. GetActiveWeapon()

--- a/src/common/shared_slots.h
+++ b/src/common/shared_slots.h
@@ -115,6 +115,7 @@
 //  [154]       left trigger analog (0..1)     plugin -> Smoking CET bridge
 //  [155]       left grip pressed (0/1)        plugin -> Smoking CET bridge
 //  [156]       DEBUG logging on (0/1)         plugin -> every CET bridge
+//  [157]       right-grip route (0=legacy, 1=RB, 2=holster)  Holster Lua -> dxgi
 // ============================================================================
 
 namespace vrshared {
@@ -149,4 +150,5 @@ constexpr int kLeftGripPressed   = 155;
 // smoking one alone in a single session, and as much again from the weapon one. A log nobody can
 // open is a log nobody reads.
 constexpr int kDebugLog          = 156;
+constexpr int kRightGripRoute    = 157;
 } // namespace vrshared

--- a/src/red4ext_plugin/main.cpp
+++ b/src/red4ext_plugin/main.cpp
@@ -7088,6 +7088,16 @@ void GetVRSharedSlot(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, float*
     int32_t idx = 0; RED4ext::GetParameter(aFrame, &idx); aFrame->code++;
     if (aOut) *aOut = (g_pSharedHands && idx >= 0 && idx < 256) ? g_pSharedHands[idx] : 0.0f;
 }
+
+// Publish the route selected by the existing CET holster-zone classifier.
+// 0 = legacy/unpublished, 1 = XInput RB, 2 = virtual holster.
+void SetVRRightGripRoute(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t) {
+    int32_t route = 0; RED4ext::GetParameter(aFrame, &route); aFrame->code++;
+    if (route < 0 || route > 2) route = 0;
+    EnsureSharedMemory();
+    if (g_pSharedHands) g_pSharedHands[vrshared::kRightGripRoute] = static_cast<float>(route);
+    if (aOut) *aOut = route;
+}
 void GetVRProvDump(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, float* aOut, int64_t) {
     int32_t idx = 0; RED4ext::GetParameter(aFrame, &idx); aFrame->code++;
     double v = 0.0;
@@ -7585,6 +7595,12 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes() {
     auto fGetSlot = RED4ext::CGlobalFunction::Create("GetVRSharedSlot", "GetVRSharedSlot", &GetVRSharedSlot);
     fGetSlot->flags = flags; fGetSlot->AddParam("Int32", "idx"); fGetSlot->SetReturnType("Float");
     rtti->RegisterFunction(fGetSlot);
+    auto fGripRoute = RED4ext::CGlobalFunction::Create(
+        "SetVRRightGripRoute", "SetVRRightGripRoute", &SetVRRightGripRoute);
+    fGripRoute->flags = flags;
+    fGripRoute->AddParam("Int32", "route");
+    fGripRoute->SetReturnType("Int32");
+    rtti->RegisterFunction(fGripRoute);
 
     auto f61 = RED4ext::CGlobalFunction::Create("SetVRWeaponAim", "SetVRWeaponAim", &SetVRWeaponAim);
     f61->flags = flags; f61->SetReturnType("Int32");

--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -112,6 +112,7 @@ struct LiveControls {
     volatile int xrXInputInstall;   // 1 = install the XInput entry-point detour at startup (default 1, set 0 in vrport.ini to fully bypass)
     volatile int xrInputActions;    // 1 = create gameplay XrActions (thumbstick/trigger/buttons). 0 = pose-only legacy behaviour
     volatile int xrFullStickSprintCrouch; // 1 = full-forward LS sends L3 and full-down RS sends R3
+    volatile int xrSwapTriggersGripsDriving; // 1 = in vehicles, VR triggers -> LB/RB and analog grips -> LT/RT
     volatile int xrMonoXQueueWait;  // 1 = mono path inserts cross-queue Wait before depth capture (legacy). 0 = skip it -- avoids CP2077 async-compute Wait cycle that froze present thread.
     volatile int xrSnapTurnPulseMs; // duration of the discrete snap turn pulse pushed into the right stick (ms)
     volatile int xrMonoDepthCapture; // 1 (default) = mono scene-depth for XR_KHR_composition_layer_depth. The resolve reads the game depth as an SRV WITHOUT transitioning it (D3D12 state is global -> barriering the game's resource device-removes CP2077), on our own capture queue (FIFO before the submit's depth copy, no cross-queue Wait), and only once the scene depth has been a stable shader-readable resource with menus closed for a warmup window (skips the intro/menu-load transient). 0 = no depth in mono.
@@ -182,6 +183,7 @@ void InitRuntimePaths() {
     g_liveControls.xrXInputInstall = 1;
     g_liveControls.xrInputActions = 1;
     g_liveControls.xrFullStickSprintCrouch = 1;
+    g_liveControls.xrSwapTriggersGripsDriving = 0;
 
     // Capture the recenter-request baseline NOW (before CET could write), so the
     // first OnGameAttached this session is seen as a change and triggers a recenter,
@@ -474,6 +476,7 @@ static void PollLiveControls() {
     int xrXInputInstall = g_liveControls.xrXInputInstall;
     int xrInputActions = g_liveControls.xrInputActions;
     int xrFullStickSprintCrouch = g_liveControls.xrFullStickSprintCrouch;
+    int xrSwapTriggersGripsDriving = g_liveControls.xrSwapTriggersGripsDriving;
     int xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
     int xrSnapTurnPulseMs = g_liveControls.xrSnapTurnPulseMs > 0 ? g_liveControls.xrSnapTurnPulseMs : 30;
     int xrMonoDepthCapture = g_liveControls.xrMonoDepthCapture;
@@ -692,6 +695,11 @@ static void PollLiveControls() {
             xrFullStickSprintCrouch = intValue;
             continue;
         }
+        if (sscanf_s(line, "xr_swap_triggers_grips_driving=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_swap_triggers_grips_driving = %d", &intValue) == 1) {
+            xrSwapTriggersGripsDriving = intValue;
+            continue;
+        }
         if (sscanf_s(line, "xr_mono_xqueue_wait=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_mono_xqueue_wait = %d", &intValue) == 1) {
             xrMonoXQueueWait = intValue;
@@ -744,6 +752,7 @@ static void PollLiveControls() {
         g_liveControls.xrPairLock != xrPairLock ||
         g_liveControls.xrRenderPoseSubmit != xrRenderPoseSubmit ||
         g_liveControls.xrFullStickSprintCrouch != xrFullStickSprintCrouch ||
+        g_liveControls.xrSwapTriggersGripsDriving != xrSwapTriggersGripsDriving ||
         g_liveControls.xrRuntime != xrRuntime ||
         g_liveControls.xrDepthSubmit != xrDepthSubmit;
 
@@ -784,6 +793,7 @@ static void PollLiveControls() {
     g_liveControls.xrXInputInstall = xrXInputInstall != 0 ? 1 : 0;
     g_liveControls.xrInputActions = xrInputActions != 0 ? 1 : 0;
     g_liveControls.xrFullStickSprintCrouch = xrFullStickSprintCrouch != 0 ? 1 : 0;
+    g_liveControls.xrSwapTriggersGripsDriving = xrSwapTriggersGripsDriving != 0 ? 1 : 0;
     g_liveControls.xrMonoXQueueWait = xrMonoXQueueWait != 0 ? 1 : 0;
     g_liveControls.xrSnapTurnPulseMs = xrSnapTurnPulseMs > 0 ? xrSnapTurnPulseMs : 30;
     g_liveControls.xrMonoDepthCapture = xrMonoDepthCapture != 0 ? 1 : 0;
@@ -847,6 +857,7 @@ static LiveControlsUiState MakeLiveControlsUiState() {
     state.xrXInputInstall = g_liveControls.xrXInputInstall;
     state.xrInputActions = g_liveControls.xrInputActions;
     state.xrFullStickSprintCrouch = g_liveControls.xrFullStickSprintCrouch;
+    state.xrSwapTriggersGripsDriving = g_liveControls.xrSwapTriggersGripsDriving;
     state.xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
     state.xrMonoDepthCapture = g_liveControls.xrMonoDepthCapture;
     state.xrSnapTurnPulseMs = g_liveControls.xrSnapTurnPulseMs;
@@ -900,6 +911,7 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_xinput_install=%d\n", state.xrXInputInstall != 0 ? 1 : 0);
     fprintf(file, "xr_input_actions=%d\n", state.xrInputActions != 0 ? 1 : 0);
     fprintf(file, "xr_full_stick_sprint_crouch=%d\n", state.xrFullStickSprintCrouch != 0 ? 1 : 0);
+    fprintf(file, "xr_swap_triggers_grips_driving=%d\n", state.xrSwapTriggersGripsDriving != 0 ? 1 : 0);
     fprintf(file, "xr_mono_xqueue_wait=%d\n", state.xrMonoXQueueWait != 0 ? 1 : 0);
     fprintf(file, "xr_mono_depth_capture=%d\n", state.xrMonoDepthCapture != 0 ? 1 : 0);
     fprintf(file, "xr_snap_turn_pulse_ms=%d\n", state.xrSnapTurnPulseMs > 0 ? state.xrSnapTurnPulseMs : 30);
@@ -964,6 +976,7 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
     g_liveControls.xrXInputInstall = state->xrXInputInstall != 0 ? 1 : 0;
     g_liveControls.xrInputActions = state->xrInputActions != 0 ? 1 : 0;
     g_liveControls.xrFullStickSprintCrouch = state->xrFullStickSprintCrouch != 0 ? 1 : 0;
+    g_liveControls.xrSwapTriggersGripsDriving = state->xrSwapTriggersGripsDriving != 0 ? 1 : 0;
     g_liveControls.xrMonoXQueueWait = state->xrMonoXQueueWait != 0 ? 1 : 0;
     g_liveControls.xrMonoDepthCapture = state->xrMonoDepthCapture != 0 ? 1 : 0;
     g_liveControls.xrSnapTurnPulseMs = state->xrSnapTurnPulseMs > 0 ? state->xrSnapTurnPulseMs : 30;
@@ -6664,6 +6677,9 @@ static bool     g_xinputHooked = false;
 static int      g_xinputSnapArmedDir = 0;       // currently latched stick direction so we don't fire while held
 static DWORD    g_xinputSnapPulseStartMs = 0;   // when the current pulse began
 static int      g_xinputSnapPulseDir = 0;       // direction of the active pulse (0 = idle)
+static bool     g_xinputRightGripWasDown = false;
+static bool     g_xinputRightGripRoutesToRb = false;
+static bool     g_xinputSuppressHolsterGripUntilRelease = false;
 
 extern "C" int GetSnapTurnPulseMs();
 
@@ -6700,26 +6716,43 @@ static DWORD WINAPI HookedXInputGetState(DWORD dwUserIndex, XINPUT_STATE* pState
         r = ERROR_SUCCESS;
     }
 
-    // Buttons: OR (so a physical pad can still augment, and vice versa).
-    pState->Gamepad.wButtons |= vr.buttons;
+    bool menuOpenForRb = (g_menuModeValue != 0);
+    float* sh = GetShotShared();
+    if (!menuOpenForRb && sh) {
+        if (reinterpret_cast<volatile uint32_t*>(sh)[81] != 0u) menuOpenForRb = true;
+    }
+    // Keep the existing LB/RB menu navigation even when the overlay is opened from a vehicle.
+    const bool swapDrivingInputs = g_isInVehicle
+        && g_liveControls.xrSwapTriggersGripsDriving != 0
+        && !menuOpenForRb;
 
-    // MENU-ONLY: right grip = RB (right shoulder) for tab navigation to the RIGHT,
-    // symmetric with the left grip's LB. The right grip is deliberately NEVER merged as
-    // RB in gameplay -- there it is reserved for the hand-to-holster equip (published as
-    // shared[49] above) and the D-pad modifier, and RB is a gameplay action that would
-    // misfire on every holster reach. Menus run no holster logic and can't fire gameplay
-    // actions, so the grip is safe as RB while one is open. Menu state = the native
-    // menu-mode hook OR the redscript world-map bridge flag (shared[81]).
+    // Buttons: OR (so a physical pad can still augment, and vice versa).
+    // When vehicle swapping is active, remove only the LB synthesized from the VR left grip;
+    // the physical gamepad state already in pState remains untouched.
+    WORD vrButtons = vr.buttons;
+    if (swapDrivingInputs) vrButtons &= ~0x0100; // XINPUT_GAMEPAD_LEFT_SHOULDER
+    pState->Gamepad.wButtons |= vrButtons;
+    if (swapDrivingInputs) {
+        if (vr.leftTrigger >= 0.7f)  pState->Gamepad.wButtons |= 0x0100; // LB
+        if (vr.rightTrigger >= 0.7f) pState->Gamepad.wButtons |= 0x0200; // RB
+    }
+
+    // Route one complete right-grip press to either RB or the existing virtual holster.
+    // The CET holster mod owns zone classification and publishes the route continuously;
+    // latch it on the press edge so moving into/out of a zone while held cannot switch paths.
     {
-        bool menuOpenForRb = (g_menuModeValue != 0);
-        if (!menuOpenForRb) {
-            if (float* sh = GetShotShared()) {
-                if (reinterpret_cast<volatile uint32_t*>(sh)[81] != 0u) menuOpenForRb = true;
-            }
+        const bool rightGripDown = vr.rightGrip >= 0.7f;
+        if (rightGripDown && !g_xinputRightGripWasDown) {
+            const int route = sh ? static_cast<int>(sh[vrshared::kRightGripRoute]) : 0;
+            g_xinputRightGripRoutesToRb = menuOpenForRb
+                || (g_isInVehicle && !swapDrivingInputs)
+                || (!g_isInVehicle && route == 1);
         }
-        if (menuOpenForRb && vr.rightGrip >= 0.7f) {
+        if (rightGripDown && g_xinputRightGripRoutesToRb && !swapDrivingInputs) {
             pState->Gamepad.wButtons |= 0x0200; // XINPUT_GAMEPAD_RIGHT_SHOULDER
         }
+        if (!rightGripDown) g_xinputRightGripRoutesToRb = false;
+        g_xinputRightGripWasDown = rightGripDown;
     }
 
     // Triggers: take the max so a physical squeeze isn't lost.
@@ -6727,8 +6760,8 @@ static DWORD WINAPI HookedXInputGetState(DWORD dwUserIndex, XINPUT_STATE* pState
     // mod sets IsBlocking/IsDeflecting directly, damageManager.script mitigates on those stats,
     // and the PSM Block state with its AimWalk/sprint debuffs is never entered. A physical left
     // trigger still reaches the game's own 'MeleeBlock' action through this merge as in flat.)
-    BYTE lt = FloatToBYTE(vr.leftTrigger);
-    BYTE rt = FloatToBYTE(vr.rightTrigger);
+    BYTE lt = FloatToBYTE(swapDrivingInputs ? vr.leftGrip : vr.leftTrigger);
+    BYTE rt = FloatToBYTE(swapDrivingInputs ? vr.rightGrip : vr.rightTrigger);
     // The VR left trigger reaches the gamepad LT (aim / zoom, melee block, VEHICLE BRAKE) unless
     // the smoking lighter has a claim on it, which is only true on foot with empty hands.
     //
@@ -6749,7 +6782,12 @@ static DWORD WINAPI HookedXInputGetState(DWORD dwUserIndex, XINPUT_STATE* pState
     // The CET hand-to-holster mod reads this + the IN-GAME wrist-to-hip distances the plugin
     // publishes from the live FK pose to decide whether reaching for a visual holster + a grip
     // press should equip / unequip the corresponding weapon.
-    OpenXRManager::Get().SetSharedSlot(49, vr.rightGrip > 0.5f ? 1.0f : 0.0f);
+    // A seated pose can overlap a body holster. Suppress the CET grip edge for the entire vehicle
+    // stay, and keep suppressing a grip already held while exiting until it is released.
+    if (g_isInVehicle) g_xinputSuppressHolsterGripUntilRelease = true;
+    if (vr.rightGrip <= 0.5f) g_xinputSuppressHolsterGripUntilRelease = false;
+    OpenXRManager::Get().SetSharedSlot(
+        49, !g_xinputSuppressHolsterGripUntilRelease && vr.rightGrip > 0.5f ? 1.0f : 0.0f);
     // LEFT hand, for the smoking mod: the lighter is ignited by the left trigger and the cigarette
     // is taken to and from the mouth with either grip, so it needs all three. Only the right grip
     // was ever published; the left pair had no channel at all, and the CET bridge was reading [67]
@@ -6768,7 +6806,8 @@ static DWORD WINAPI HookedXInputGetState(DWORD dwUserIndex, XINPUT_STATE* pState
     // count it down. Otherwise merge the physical trigger into RT normally (guns shooting / held attack).
     float meleeImpulse = OpenXRManager::Get().GetSharedSlot(29);
     if (meleeImpulse > 0.5f) {
-        pState->Gamepad.bRightTrigger = 255;
+        if (!g_isInVehicle) pState->Gamepad.bRightTrigger = 255;
+        else if (rt > pState->Gamepad.bRightTrigger) pState->Gamepad.bRightTrigger = rt;
         OpenXRManager::Get().SetSharedSlot(29, meleeImpulse - 1.0f);
     } else {
         if (rt > pState->Gamepad.bRightTrigger) pState->Gamepad.bRightTrigger = rt;

--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -111,6 +111,8 @@ struct LiveControls {
     volatile int xrMovementSource;  // 0 = Game, 1 = HMD, 2 = LeftHand, 3 = RightHand
     volatile int xrXInputInstall;   // 1 = install the XInput entry-point detour at startup (default 1, set 0 in vrport.ini to fully bypass)
     volatile int xrInputActions;    // 1 = create gameplay XrActions (thumbstick/trigger/buttons). 0 = pose-only legacy behaviour
+    volatile int xrChordActivation; // 0 = left L3, 1 = right R3, 2 = right thumbrest
+    volatile int xrExtraChordActions; // 1 = recenter/F10 chord actions; D-pad and Back remain unconditional
     volatile int xrFullStickSprintCrouch; // 1 = full-forward LS sends L3 and full-down RS sends R3
     volatile int xrSwapTriggersGripsDriving; // 1 = in vehicles, VR triggers -> LB/RB and analog grips -> LT/RT
     volatile int xrMonoXQueueWait;  // 1 = mono path inserts cross-queue Wait before depth capture (legacy). 0 = skip it -- avoids CP2077 async-compute Wait cycle that froze present thread.
@@ -182,6 +184,8 @@ void InitRuntimePaths() {
     // the binding/entry-point patch keeps the game from reaching its main menu.
     g_liveControls.xrXInputInstall = 1;
     g_liveControls.xrInputActions = 1;
+    g_liveControls.xrChordActivation = 0;
+    g_liveControls.xrExtraChordActions = 1;
     g_liveControls.xrFullStickSprintCrouch = 1;
     g_liveControls.xrSwapTriggersGripsDriving = 0;
 
@@ -256,6 +260,8 @@ static void EnsureLiveControlFileExists() {
     // from reaching its main menu.
     fprintf(file, "xr_xinput_install=1\n");
     fprintf(file, "xr_input_actions=1\n");
+    fprintf(file, "xr_chord_activation=0\n");
+    fprintf(file, "xr_extra_chord_actions=1\n");
     fprintf(file, "xr_mono_xqueue_wait=0\n");
     fprintf(file, "xr_snap_turn_pulse_ms=30\n");
     fprintf(file, "xr_mono_depth_capture=1\n");
@@ -475,6 +481,8 @@ static void PollLiveControls() {
     int xrMovementSource = g_liveControls.xrMovementSource;
     int xrXInputInstall = g_liveControls.xrXInputInstall;
     int xrInputActions = g_liveControls.xrInputActions;
+    int xrChordActivation = g_liveControls.xrChordActivation;
+    int xrExtraChordActions = g_liveControls.xrExtraChordActions;
     int xrFullStickSprintCrouch = g_liveControls.xrFullStickSprintCrouch;
     int xrSwapTriggersGripsDriving = g_liveControls.xrSwapTriggersGripsDriving;
     int xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
@@ -690,6 +698,16 @@ static void PollLiveControls() {
             xrInputActions = intValue;
             continue;
         }
+        if (sscanf_s(line, "xr_chord_activation=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_chord_activation = %d", &intValue) == 1) {
+            xrChordActivation = intValue;
+            continue;
+        }
+        if (sscanf_s(line, "xr_extra_chord_actions=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_extra_chord_actions = %d", &intValue) == 1) {
+            xrExtraChordActions = intValue;
+            continue;
+        }
         if (sscanf_s(line, "xr_full_stick_sprint_crouch=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_full_stick_sprint_crouch = %d", &intValue) == 1) {
             xrFullStickSprintCrouch = intValue;
@@ -751,6 +769,8 @@ static void PollLiveControls() {
         g_liveControls.xrReuseLastFrame != xrReuseLastFrame ||
         g_liveControls.xrPairLock != xrPairLock ||
         g_liveControls.xrRenderPoseSubmit != xrRenderPoseSubmit ||
+        g_liveControls.xrChordActivation != xrChordActivation ||
+        g_liveControls.xrExtraChordActions != xrExtraChordActions ||
         g_liveControls.xrFullStickSprintCrouch != xrFullStickSprintCrouch ||
         g_liveControls.xrSwapTriggersGripsDriving != xrSwapTriggersGripsDriving ||
         g_liveControls.xrRuntime != xrRuntime ||
@@ -792,6 +812,8 @@ static void PollLiveControls() {
     g_liveControls.xrSnapTurnAngleDeg = xrSnapTurnAngleDeg > 0.0f ? xrSnapTurnAngleDeg : 30.0f;
     g_liveControls.xrXInputInstall = xrXInputInstall != 0 ? 1 : 0;
     g_liveControls.xrInputActions = xrInputActions != 0 ? 1 : 0;
+    g_liveControls.xrChordActivation = (xrChordActivation >= 0 && xrChordActivation <= 2) ? xrChordActivation : 0;
+    g_liveControls.xrExtraChordActions = xrExtraChordActions != 0 ? 1 : 0;
     g_liveControls.xrFullStickSprintCrouch = xrFullStickSprintCrouch != 0 ? 1 : 0;
     g_liveControls.xrSwapTriggersGripsDriving = xrSwapTriggersGripsDriving != 0 ? 1 : 0;
     g_liveControls.xrMonoXQueueWait = xrMonoXQueueWait != 0 ? 1 : 0;
@@ -856,6 +878,8 @@ static LiveControlsUiState MakeLiveControlsUiState() {
     state.xrPhysicalBodyRotation = g_liveControls.xrPhysicalBodyRotation;
     state.xrXInputInstall = g_liveControls.xrXInputInstall;
     state.xrInputActions = g_liveControls.xrInputActions;
+    state.xrChordActivation = g_liveControls.xrChordActivation;
+    state.xrExtraChordActions = g_liveControls.xrExtraChordActions;
     state.xrFullStickSprintCrouch = g_liveControls.xrFullStickSprintCrouch;
     state.xrSwapTriggersGripsDriving = g_liveControls.xrSwapTriggersGripsDriving;
     state.xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
@@ -910,6 +934,8 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_physical_body_rotation=%d\n", state.xrPhysicalBodyRotation != 0 ? 1 : 0);
     fprintf(file, "xr_xinput_install=%d\n", state.xrXInputInstall != 0 ? 1 : 0);
     fprintf(file, "xr_input_actions=%d\n", state.xrInputActions != 0 ? 1 : 0);
+    fprintf(file, "xr_chord_activation=%d\n", (state.xrChordActivation >= 0 && state.xrChordActivation <= 2) ? state.xrChordActivation : 0);
+    fprintf(file, "xr_extra_chord_actions=%d\n", state.xrExtraChordActions != 0 ? 1 : 0);
     fprintf(file, "xr_full_stick_sprint_crouch=%d\n", state.xrFullStickSprintCrouch != 0 ? 1 : 0);
     fprintf(file, "xr_swap_triggers_grips_driving=%d\n", state.xrSwapTriggersGripsDriving != 0 ? 1 : 0);
     fprintf(file, "xr_mono_xqueue_wait=%d\n", state.xrMonoXQueueWait != 0 ? 1 : 0);
@@ -975,6 +1001,8 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
     g_liveControls.xrSnapTurnAngleDeg = state->xrSnapTurnAngleDeg > 0.0f ? state->xrSnapTurnAngleDeg : 30.0f;
     g_liveControls.xrXInputInstall = state->xrXInputInstall != 0 ? 1 : 0;
     g_liveControls.xrInputActions = state->xrInputActions != 0 ? 1 : 0;
+    g_liveControls.xrChordActivation = (state->xrChordActivation >= 0 && state->xrChordActivation <= 2) ? state->xrChordActivation : 0;
+    g_liveControls.xrExtraChordActions = state->xrExtraChordActions != 0 ? 1 : 0;
     g_liveControls.xrFullStickSprintCrouch = state->xrFullStickSprintCrouch != 0 ? 1 : 0;
     g_liveControls.xrSwapTriggersGripsDriving = state->xrSwapTriggersGripsDriving != 0 ? 1 : 0;
     g_liveControls.xrMonoXQueueWait = state->xrMonoXQueueWait != 0 ? 1 : 0;
@@ -1363,6 +1391,15 @@ extern "C" int GetXrRuntimeMode() {
 
 extern "C" int GetInputActionsEnabled() {
     return g_liveControls.xrInputActions != 0 ? 1 : 0;
+}
+
+extern "C" int GetChordActivationMethod() {
+    const int value = g_liveControls.xrChordActivation;
+    return (value >= 0 && value <= 2) ? value : 0;
+}
+
+extern "C" int GetExtraChordActionsEnabled() {
+    return g_liveControls.xrExtraChordActions != 0 ? 1 : 0;
 }
 
 extern "C" int GetMonoXQueueWait() {
@@ -7395,4 +7432,3 @@ static void InitStereoOnce() {
 __declspec(dllexport) void CyberpunkVRPort_InitStereo() { InitStereoOnce(); }
 
 }
-

--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -111,6 +111,7 @@ struct LiveControls {
     volatile int xrMovementSource;  // 0 = Game, 1 = HMD, 2 = LeftHand, 3 = RightHand
     volatile int xrXInputInstall;   // 1 = install the XInput entry-point detour at startup (default 1, set 0 in vrport.ini to fully bypass)
     volatile int xrInputActions;    // 1 = create gameplay XrActions (thumbstick/trigger/buttons). 0 = pose-only legacy behaviour
+    volatile int xrFullStickSprintCrouch; // 1 = full-forward LS sends L3 and full-down RS sends R3
     volatile int xrMonoXQueueWait;  // 1 = mono path inserts cross-queue Wait before depth capture (legacy). 0 = skip it -- avoids CP2077 async-compute Wait cycle that froze present thread.
     volatile int xrSnapTurnPulseMs; // duration of the discrete snap turn pulse pushed into the right stick (ms)
     volatile int xrMonoDepthCapture; // 1 (default) = mono scene-depth for XR_KHR_composition_layer_depth. The resolve reads the game depth as an SRV WITHOUT transitioning it (D3D12 state is global -> barriering the game's resource device-removes CP2077), on our own capture queue (FIFO before the submit's depth copy, no cross-queue Wait), and only once the scene depth has been a stable shader-readable resource with menus closed for a warmup window (skips the intro/menu-load transient). 0 = no depth in mono.
@@ -180,6 +181,7 @@ void InitRuntimePaths() {
     // the binding/entry-point patch keeps the game from reaching its main menu.
     g_liveControls.xrXInputInstall = 1;
     g_liveControls.xrInputActions = 1;
+    g_liveControls.xrFullStickSprintCrouch = 1;
 
     // Capture the recenter-request baseline NOW (before CET could write), so the
     // first OnGameAttached this session is seen as a change and triggers a recenter,
@@ -471,6 +473,7 @@ static void PollLiveControls() {
     int xrMovementSource = g_liveControls.xrMovementSource;
     int xrXInputInstall = g_liveControls.xrXInputInstall;
     int xrInputActions = g_liveControls.xrInputActions;
+    int xrFullStickSprintCrouch = g_liveControls.xrFullStickSprintCrouch;
     int xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
     int xrSnapTurnPulseMs = g_liveControls.xrSnapTurnPulseMs > 0 ? g_liveControls.xrSnapTurnPulseMs : 30;
     int xrMonoDepthCapture = g_liveControls.xrMonoDepthCapture;
@@ -684,6 +687,11 @@ static void PollLiveControls() {
             xrInputActions = intValue;
             continue;
         }
+        if (sscanf_s(line, "xr_full_stick_sprint_crouch=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_full_stick_sprint_crouch = %d", &intValue) == 1) {
+            xrFullStickSprintCrouch = intValue;
+            continue;
+        }
         if (sscanf_s(line, "xr_mono_xqueue_wait=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_mono_xqueue_wait = %d", &intValue) == 1) {
             xrMonoXQueueWait = intValue;
@@ -735,6 +743,7 @@ static void PollLiveControls() {
         g_liveControls.xrReuseLastFrame != xrReuseLastFrame ||
         g_liveControls.xrPairLock != xrPairLock ||
         g_liveControls.xrRenderPoseSubmit != xrRenderPoseSubmit ||
+        g_liveControls.xrFullStickSprintCrouch != xrFullStickSprintCrouch ||
         g_liveControls.xrRuntime != xrRuntime ||
         g_liveControls.xrDepthSubmit != xrDepthSubmit;
 
@@ -774,6 +783,7 @@ static void PollLiveControls() {
     g_liveControls.xrSnapTurnAngleDeg = xrSnapTurnAngleDeg > 0.0f ? xrSnapTurnAngleDeg : 30.0f;
     g_liveControls.xrXInputInstall = xrXInputInstall != 0 ? 1 : 0;
     g_liveControls.xrInputActions = xrInputActions != 0 ? 1 : 0;
+    g_liveControls.xrFullStickSprintCrouch = xrFullStickSprintCrouch != 0 ? 1 : 0;
     g_liveControls.xrMonoXQueueWait = xrMonoXQueueWait != 0 ? 1 : 0;
     g_liveControls.xrSnapTurnPulseMs = xrSnapTurnPulseMs > 0 ? xrSnapTurnPulseMs : 30;
     g_liveControls.xrMonoDepthCapture = xrMonoDepthCapture != 0 ? 1 : 0;
@@ -836,6 +846,7 @@ static LiveControlsUiState MakeLiveControlsUiState() {
     state.xrPhysicalBodyRotation = g_liveControls.xrPhysicalBodyRotation;
     state.xrXInputInstall = g_liveControls.xrXInputInstall;
     state.xrInputActions = g_liveControls.xrInputActions;
+    state.xrFullStickSprintCrouch = g_liveControls.xrFullStickSprintCrouch;
     state.xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
     state.xrMonoDepthCapture = g_liveControls.xrMonoDepthCapture;
     state.xrSnapTurnPulseMs = g_liveControls.xrSnapTurnPulseMs;
@@ -888,6 +899,7 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_physical_body_rotation=%d\n", state.xrPhysicalBodyRotation != 0 ? 1 : 0);
     fprintf(file, "xr_xinput_install=%d\n", state.xrXInputInstall != 0 ? 1 : 0);
     fprintf(file, "xr_input_actions=%d\n", state.xrInputActions != 0 ? 1 : 0);
+    fprintf(file, "xr_full_stick_sprint_crouch=%d\n", state.xrFullStickSprintCrouch != 0 ? 1 : 0);
     fprintf(file, "xr_mono_xqueue_wait=%d\n", state.xrMonoXQueueWait != 0 ? 1 : 0);
     fprintf(file, "xr_mono_depth_capture=%d\n", state.xrMonoDepthCapture != 0 ? 1 : 0);
     fprintf(file, "xr_snap_turn_pulse_ms=%d\n", state.xrSnapTurnPulseMs > 0 ? state.xrSnapTurnPulseMs : 30);
@@ -951,6 +963,7 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
     g_liveControls.xrSnapTurnAngleDeg = state->xrSnapTurnAngleDeg > 0.0f ? state->xrSnapTurnAngleDeg : 30.0f;
     g_liveControls.xrXInputInstall = state->xrXInputInstall != 0 ? 1 : 0;
     g_liveControls.xrInputActions = state->xrInputActions != 0 ? 1 : 0;
+    g_liveControls.xrFullStickSprintCrouch = state->xrFullStickSprintCrouch != 0 ? 1 : 0;
     g_liveControls.xrMonoXQueueWait = state->xrMonoXQueueWait != 0 ? 1 : 0;
     g_liveControls.xrMonoDepthCapture = state->xrMonoDepthCapture != 0 ? 1 : 0;
     g_liveControls.xrSnapTurnPulseMs = state->xrSnapTurnPulseMs > 0 ? state->xrSnapTurnPulseMs : 30;
@@ -6768,13 +6781,14 @@ static DWORD WINAPI HookedXInputGetState(DWORD dwUserIndex, XINPUT_STATE* pState
     if (fabsf(lx) > fabsf(pState->Gamepad.sThumbLX / 32767.0f)) pState->Gamepad.sThumbLX = FloatToSHORT(lx);
     if (fabsf(ly) > fabsf(pState->Gamepad.sThumbLY / 32767.0f)) pState->Gamepad.sThumbLY = FloatToSHORT(ly);
 
-    // Left stick pushed near FULL forward => SPRINT. A partial push is left as the
-    // game's normal jog; only "to the stop" sprints. CP2077 sprint is the left-stick
+    // When enabled, left stick pushed near FULL forward => SPRINT. A partial push is
+    // left as the game's normal jog; only "to the stop" sprints. CP2077 sprint is the left-stick
     // click (L3), so we just assert L3 while the stick is forward past the threshold
     // -- no more clicking the stick. Level-triggered (held while past the threshold)
     // mirrors physically holding L3: correct for hold-to-sprint, and toggle-sprint
     // auto-cancels on slow-down so it stays in sync as well.
-    const bool wantSprint = (ly > 0.90f);
+    const bool fullStickActions = g_liveControls.xrFullStickSprintCrouch != 0;
+    const bool wantSprint = fullStickActions && (ly > 0.90f);
     // Published for the snap-event machinery: DURING SPRINT the game RATE-LIMITS heading
     // changes (sprint turns arc over several frames instead of jumping), so the instant
     // packet pre-rotation must be suppressed there (OnFootDeltaHeadCallback).
@@ -6784,11 +6798,11 @@ static DWORD WINAPI HookedXInputGetState(DWORD dwUserIndex, XINPUT_STATE* pState
     float rx = ApplyStickDeadzone(vr.rightThumbX, 0.18f);
     float ry = ApplyStickDeadzone(vr.rightThumbY, 0.18f);
 
-    // Right stick pushed near FULL down => CROUCH. Same bind as the right-stick click
+    // When enabled, right stick pushed near FULL down => CROUCH. Same bind as the right-stick click
     // (R3) used today; we assert R3 while the stick is held fully down and consume the
     // downward Y so it doesn't also drive camera pitch. Detected here, before the snap
     // turn block may zero ry, so it works regardless of the turn mode.
-    const bool wantCrouch = (ry < -0.90f);
+    const bool wantCrouch = fullStickActions && (ry < -0.90f);
     if (wantCrouch) ry = 0.0f;
 
     // Suppress pitch from the stick if the user wants HMD-only pitch.
@@ -7342,5 +7356,4 @@ static void InitStereoOnce() {
 __declspec(dllexport) void CyberpunkVRPort_InitStereo() { InitStereoOnce(); }
 
 }
-
 

--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -1868,6 +1868,7 @@ static void ApplyKnownResolutionOverrides() {
 }
 
 static volatile float g_pitchOverrideValue = 0.0f;
+static volatile float g_gamePitchRadians = 0.0f;
 // THE ENGINE'S FOV FIELD IS VERTICAL. Measured live in x64dbg on the MAIN view context: we wrote
 // 94.0 (the de-canted horizontal) and the frustum came back tan(V/2) = 1.072369 -- exactly tan 47,
 // i.e. the engine took our number as the VERTICAL -- with tan(H/2) = 1.002432, which is precisely
@@ -2268,8 +2269,8 @@ extern "C" __declspec(dllexport) int CyberpunkVR_CamWriteInPatch = 1;
 // LocateCamera publishes the HEADING only; PatchCamera multiplies it by the HMD pose and
 // writes the product. The split follows how fast each part moves:
 //
-//   heading - mouse/stick yaw, recenter, physical-body realign. Gameplay-rate, and a value one
-//             interval old is not detectable in it.
+//   heading - mouse/stick yaw and optional pitch, recenter, physical-body realign. Gameplay-rate,
+//             and a value one interval old is not detectable in it.
 //   HMD     - the whole point. It has to be the sample belonging to the frame being built, and
 //             only the write site knows when that is.
 //
@@ -2279,8 +2280,10 @@ extern "C" __declspec(dllexport) int CyberpunkVR_CamWriteInPatch = 1;
 // Whenever Patch leads, it writes the PREVIOUS interval's product -- a full frame of
 // orientation lag that never catches up, and an image that does not match the pose submitted
 // with it. Composing here takes the ordering out of the answer entirely.
-static volatile float g_headingSy = 0.0f;      // heading quaternion is (0, 0, sy, cy)
+static volatile float g_headingSy = 0.0f;
 static volatile float g_headingCy = 1.0f;
+static volatile float g_headingPitchS = 0.0f;  // pitch quaternion is (s, 0, 0, c)
+static volatile float g_headingPitchC = 1.0f;
 static volatile uint32_t g_headingValid = 0;   // 0 on the shot frame / native-aim mode
 
 // The product actually written into both cameras, composed once per present interval.
@@ -3104,18 +3107,25 @@ extern "C" void __fastcall OnLocateCameraCallback(float* rbxPtr, float xmm0_val)
         // at the pair boundary (UpdatePairLock + FlushHandsToShared), before the next
         // pair's animation.
 
-        // Keep mouse/controller yaw as the body heading, but do not add mouse-Y pitch
-        // on top of HMD pitch. The headset supplies vertical look in VR.
+        // The headset supplies vertical look when mouse-Y pitch is disabled. When it is
+        // enabled, preserve the game's pitch and compose it with the HMD orientation.
         const float gameYaw = atan2f(-bodyGameForwardX, bodyGameForwardY);
+        const float gamePitch = g_liveControls.xrDisableMouseY != 0
+            ? 0.0f
+            : g_gamePitchRadians;
         const float cy = cosf(gameYaw * 0.5f);
         const float sy = sinf(gameYaw * 0.5f);
+        const float pc = cosf(gamePitch * 0.5f);
+        const float ps = sinf(gamePitch * 0.5f);
 
-        // Publish the heading for the write site. This -- not the finished product -- is what
+        // Publish the game orientation for the write site. This -- not the finished product -- is what
         // this hook is uniquely able to produce: it is the only place that has the body
         // forward, the recenter base and the physical-rotation realign. The HMD half is
         // multiplied in at the write, where it can be current.
         g_headingSy = sy;
         g_headingCy = cy;
+        g_headingPitchS = ps;
+        g_headingPitchC = pc;
         g_headingValid = skipHmdOrientation ? 0u : 1u;
         CyberpunkVR_DebugTidLocateCam = GetCurrentThreadId();
 
@@ -3124,14 +3134,18 @@ extern "C" void __fastcall OnLocateCameraCallback(float* rbxPtr, float xmm0_val)
         const float xrGameZ = xrPose.oriY;
         const float xrGameW = xrPose.oriW;
 
-        // Camera = heading * FULL HMD orientation in EVERY on-foot mode. With physical
+        // Camera = game orientation * FULL HMD orientation in EVERY on-foot mode. With physical
         // body rotation ON, body-realign (OnOnFootDeltaHead) turns the game HEADING only
         // on a PHYSICAL body turn and rotates the recenter base by the same angle, so a
         // head-only turn moves the VIEW but leaves the body/heading put. (The old unarmed
         // branch stripped the HMD yaw and glued the heading to it, which rotated the body
         // on every head turn -- replaced by the realign model.)
+        float headingX, headingY, headingZ, headingW;
+        MulQuat(0.0f, 0.0f, sy, cy, ps, 0.0f, 0.0f, pc,
+            headingX, headingY, headingZ, headingW);
         float tmpX, tmpY, tmpZ, tmpW;
-        MulQuat(0.0f, 0.0f, sy, cy, xrGameX, xrGameY, xrGameZ, xrGameW, tmpX, tmpY, tmpZ, tmpW);
+        MulQuat(headingX, headingY, headingZ, headingW,
+            xrGameX, xrGameY, xrGameZ, xrGameW, tmpX, tmpY, tmpZ, tmpW);
         NormalizeQuat(tmpX, tmpY, tmpZ, tmpW);
 
         camera_qx = tmpX;
@@ -3836,7 +3850,7 @@ extern "C" void __fastcall OnPatchCameraCallback(float* cameraState, void* owner
 
     // ---- ORIENTATION: the head pose, into BOTH cameras ------------------------------------
     //
-    // This is what makes VRCAM track. LocateCamera composed heading * HMD for this frame and
+    // This is what makes VRCAM track. LocateCamera composed game orientation * HMD for this frame and
     // published it; here it goes into the camera's own quaternion store, which is what the
     // rest of the frame reads. Both cameras get the SAME orientation -- the eyes differ by the
     // lateral IPD offset below, not by where they look.
@@ -3927,8 +3941,12 @@ extern "C" void __fastcall OnPatchCameraCallback(float* cameraState, void* owner
                 }
                 if (got) {
                     // Same axis mapping LocateCamera uses: XR (x, y, z) -> game (x, -z, y).
-                    float rx, ry, rz, rw;
+                    float headingX, headingY, headingZ, headingW;
                     MulQuat(0.0f, 0.0f, g_headingSy, g_headingCy,
+                            g_headingPitchS, 0.0f, 0.0f, g_headingPitchC,
+                            headingX, headingY, headingZ, headingW);
+                    float rx, ry, rz, rw;
+                    MulQuat(headingX, headingY, headingZ, headingW,
                             p.oriX, -p.oriZ, p.oriY, p.oriW, rx, ry, rz, rw);
                     NormalizeQuat(rx, ry, rz, rw);
                     CamWriteQuatPublish(rx, ry, rz, rw);
@@ -4518,18 +4536,22 @@ extern "C" void __fastcall OnPitchHookCallback(void* pitchState, float originalP
     g_pitchHookHits++;
 
     // Mouse-Y pitch in CP2077 also drives a constrained camera pivot offset, which
-    // moves the head toward/away from the body in VR. Keep the game pitch neutral;
-    // HMD pitch is applied visually in LocateCamera instead.
-    const float desiredPitch = 0.0f;
+    // moves the head toward/away from the body in VR. Keep the game pitch neutral
+    // only when HMD-only pitch is enabled; otherwise preserve the game input.
+    const float desiredPitch = g_liveControls.xrDisableMouseY != 0 ? 0.0f : originalPitch;
+
+    float minPitch = 0.0f;
+    float maxPitch = 0.0f;
+    ReadFloatSafe(reinterpret_cast<uintptr_t>(pitchState) + 0x14, &minPitch);
+    ReadFloatSafe(reinterpret_cast<uintptr_t>(pitchState) + 0x18, &maxPitch);
+    const float clampedPitch = (std::max)(minPitch, (std::min)(maxPitch, desiredPitch));
+    const bool pitchUsesDegrees = fabsf(minPitch) > 3.2f || fabsf(maxPitch) > 3.2f;
+    g_gamePitchRadians = clampedPitch * (pitchUsesDegrees ? 0.01745329252f : 1.0f);
 
     g_pitchOverrideValue = desiredPitch;
 
     if (g_verboseLog && (g_pitchHookHits % 600) == 1) {
-        float minPitch = 0.0f;
-        float maxPitch = 0.0f;
-        ReadFloatSafe(reinterpret_cast<uintptr_t>(pitchState) + 0x14, &minPitch);
-        ReadFloatSafe(reinterpret_cast<uintptr_t>(pitchState) + 0x18, &maxPitch);
-        Log("Pitch hook: state=%p original=%.6f neutral=%.6f clamp=[%.6f, %.6f]\n",
+        Log("Pitch hook: state=%p original=%.6f desired=%.6f clamp=[%.6f, %.6f]\n",
             pitchState,
             originalPitch,
             desiredPitch,
@@ -6797,7 +6819,6 @@ static DWORD WINAPI HookedXInputGetState(DWORD dwUserIndex, XINPUT_STATE* pState
         }
         // Stick X is consumed by the snap turn, so do not pass it to the game.
         rx = 0.0f;
-        ry = 0.0f;
     }
 
     if (fabsf(rx) > fabsf(pState->Gamepad.sThumbRX / 32767.0f)) pState->Gamepad.sThumbRX = FloatToSHORT(rx);

--- a/src/vr/openxr/openxr_frameloop.cpp
+++ b/src/vr/openxr/openxr_frameloop.cpp
@@ -6,6 +6,7 @@
 #include "openxr_math.h"
 #include "shared_slots.h"
 #include "runtime_fov_correction.h"
+#include "../overlay/imgui_overlay.h"
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -649,10 +650,45 @@ DWORD OpenXRManager::FrameThreadMain() {
                 // for-byte identical to the pre-Controls-tab behaviour.
                 const bool gameplayInputActive = (GetInputActionsEnabled() != 0) && (m_thumbstickAction != XR_NULL_HANDLE);
                 VRControllerState ctrl{};
-                // D-PAD chord state (left hand is processed first, right second):
-                // HOLD the LEFT stick click, pick the direction with the RIGHT stick.
-                bool leftStickClicked  = false;
-                bool dpadUsedThisFrame = false;
+                float stickX[2]{};
+                float stickY[2]{};
+                bool stickClicked[2]{};
+                bool primaryPressed[2]{};
+                bool secondaryPressed[2]{};
+
+                constexpr uint16_t XB_DPAD_UP        = 0x0001;
+                constexpr uint16_t XB_DPAD_DOWN      = 0x0002;
+                constexpr uint16_t XB_DPAD_LEFT      = 0x0004;
+                constexpr uint16_t XB_DPAD_RIGHT     = 0x0008;
+                constexpr uint16_t XB_START          = 0x0010;
+                constexpr uint16_t XB_BACK           = 0x0020;
+                constexpr uint16_t XB_LEFT_THUMB     = 0x0040;
+                constexpr uint16_t XB_RIGHT_THUMB    = 0x0080;
+                constexpr uint16_t XB_LEFT_SHOULDER  = 0x0100;
+                constexpr uint16_t XB_A              = 0x1000;
+                constexpr uint16_t XB_B              = 0x2000;
+                constexpr uint16_t XB_X              = 0x4000;
+                constexpr uint16_t XB_Y              = 0x8000;
+
+                bool rightThumbrestTouched = false;
+                bool rightThumbrestAvailable = m_rightThumbrestAvailable.load(std::memory_order_relaxed);
+                if (gameplayInputActive
+                    && !m_rightThumbrestProfileKnown.load(std::memory_order_relaxed)) {
+                    RefreshRightThumbrestAvailability();
+                    rightThumbrestAvailable = m_rightThumbrestAvailable.load(std::memory_order_relaxed);
+                }
+                if (gameplayInputActive && m_rightThumbrestAction != XR_NULL_HANDLE) {
+                    XrActionStateGetInfo gi{XR_TYPE_ACTION_STATE_GET_INFO};
+                    gi.action = m_rightThumbrestAction;
+                    gi.subactionPath = XR_NULL_PATH;
+                    XrActionStateBoolean st{XR_TYPE_ACTION_STATE_BOOLEAN};
+                    if (XR_SUCCEEDED(xrGetActionStateBoolean(m_session, &gi, &st)) && st.isActive) {
+                        rightThumbrestAvailable = true;
+                        m_rightThumbrestProfileKnown.store(true, std::memory_order_relaxed);
+                        rightThumbrestTouched = st.currentState != XR_FALSE;
+                    }
+                }
+                m_rightThumbrestAvailable.store(rightThumbrestAvailable, std::memory_order_relaxed);
 
                 std::lock_guard<std::mutex> handLock(m_handMutex);
                 // ONE INSTANT: the head position that goes with these controller poses, plus the
@@ -824,59 +860,23 @@ DWORD OpenXRManager::FrameThreadMain() {
                     const bool prim   = getBool(m_primaryButtonAction);
                     const bool sec    = getBool(m_secondaryButtonAction);
 
-                    // XInput-compatible button bits so the hook can OR them into
-                    // XINPUT_GAMEPAD.wButtons directly (XINPUT_GAMEPAD_*).
-                    constexpr uint16_t XB_A              = 0x1000;
-                    constexpr uint16_t XB_B              = 0x2000;
-                    constexpr uint16_t XB_X              = 0x4000;
-                    constexpr uint16_t XB_Y              = 0x8000;
-                    constexpr uint16_t XB_LEFT_SHOULDER  = 0x0100;
-                    constexpr uint16_t XB_RIGHT_SHOULDER = 0x0200;
-                    constexpr uint16_t XB_LEFT_THUMB     = 0x0040;
-                    constexpr uint16_t XB_RIGHT_THUMB    = 0x0080;
-                    constexpr uint16_t XB_DPAD_UP        = 0x0001;
-                    constexpr uint16_t XB_DPAD_DOWN      = 0x0002;
-                    constexpr uint16_t XB_DPAD_LEFT     = 0x0004;
-                    constexpr uint16_t XB_DPAD_RIGHT     = 0x0008;
-                    (void)XB_LEFT_THUMB;
+                    stickX[i] = sx;
+                    stickY[i] = sy;
+                    stickClicked[i] = sclick;
+                    primaryPressed[i] = prim;
+                    secondaryPressed[i] = sec;
 
                     if (i == 0) {
                         ctrl.leftTrigger = trig;
                         ctrl.leftGrip    = grip;
                         ctrl.leftThumbX  = sx;
                         ctrl.leftThumbY  = sy;
-                        if (prim)   ctrl.buttons |= XB_X;
-                        if (sec)    ctrl.buttons |= XB_Y;
                         if (grip >= 0.7f) ctrl.buttons |= XB_LEFT_SHOULDER;
-
-                        // LEFT stick click = D-Pad modifier (direction picked with the
-                        // RIGHT stick, see the right-hand branch). The vanilla L3
-                        // (sprint) is emitted DEFERRED, after the loop: only when the
-                        // click is released without a D-Pad direction having been used.
-                        leftStickClicked = sclick;
                     } else {
                         ctrl.rightTrigger = trig;
                         ctrl.rightGrip    = grip;
                         ctrl.rightThumbX  = sx;
                         ctrl.rightThumbY  = sy;
-                        if (sclick) ctrl.buttons |= XB_RIGHT_THUMB;
-                        if (prim)   ctrl.buttons |= XB_A;
-                        if (sec)    ctrl.buttons |= XB_B;
-
-                        // D-PAD CHORD: while the LEFT stick click is held, the RIGHT
-                        // stick picks the D-Pad direction. The right axes are zeroed for
-                        // the whole hold so snap-turn/camera cannot fire during selection.
-                        if (leftStickClicked) {
-                            constexpr float threshold = 0.5f;
-                            if (sy > threshold)  { ctrl.buttons |= XB_DPAD_UP;    dpadUsedThisFrame = true; }
-                            if (sy < -threshold) { ctrl.buttons |= XB_DPAD_DOWN;  dpadUsedThisFrame = true; }
-                            if (sx < -threshold) { ctrl.buttons |= XB_DPAD_LEFT;  dpadUsedThisFrame = true; }
-                            if (sx > threshold)  { ctrl.buttons |= XB_DPAD_RIGHT; dpadUsedThisFrame = true; }
-                            ctrl.rightThumbX = 0.0f;
-                            ctrl.rightThumbY = 0.0f;
-                        }
-
-
                         // Right grip is RESERVED for the hand-to-holster equip system: a CET mod reads
                         // the grip value (shared[31] or similar) and the controller pose, and equips the
                         // weapon whose visual holster the hand is touching. Do NOT merge into XInput as
@@ -885,39 +885,198 @@ DWORD OpenXRManager::FrameThreadMain() {
                     }
                 }
 
-                // DEFERRED L3 (sprint): the left stick click doubles as the D-Pad
-                // modifier. Emit the vanilla stick-click press only when the click is
-                // RELEASED without any D-Pad direction having been used during the hold
-                // (one-frame press; the game latches button edges per poll).
-                {
-                    static bool s_l3Held = false;
-                    static bool s_l3UsedForDpad = false;
-                    if (leftStickClicked) {
-                        if (dpadUsedThisFrame) s_l3UsedForDpad = true;
-                        s_l3Held = true;
-                    } else {
-                        if (s_l3Held && !s_l3UsedForDpad)
-                            ctrl.buttons |= 0x0040;   // XINPUT_GAMEPAD_LEFT_THUMB
-                        s_l3Held = false;
-                        s_l3UsedForDpad = false;
-                    }
-                }
+                struct ChordRuntimeState {
+                    int effectiveMode = -1;
+                    bool modifierHeld = false;
+                    bool modifierPassthrough = false;
+                    bool modifierDeferred = false;
+                    bool chordConsumed = false;
+                    bool dpadArmed = false;
+                    bool menuDown = false;
+                    bool menuChorded = false;
+                    bool faceWasDown[4]{};       // X, Y, A, B
+                    bool faceChordLatched[4]{};  // suppress until the physical button is released
+                    uint16_t deferredTapButton = 0;
+                    uint64_t deferredTapUntilMs = 0;
+                };
+                static ChordRuntimeState s_chord{};
 
                 if (gameplayInputActive) {
-                    // Menu button is single (no per-hand binding) on Touch/Index/Vive/WMR.
+                    bool menuPressed = false;
                     if (m_menuButtonAction != XR_NULL_HANDLE) {
                         XrActionStateGetInfo gi{XR_TYPE_ACTION_STATE_GET_INFO};
                         gi.action = m_menuButtonAction;
                         gi.subactionPath = XR_NULL_PATH;
                         XrActionStateBoolean st{XR_TYPE_ACTION_STATE_BOOLEAN};
-                        if (XR_SUCCEEDED(xrGetActionStateBoolean(m_session, &gi, &st)) && st.isActive && st.currentState)
-                            ctrl.buttons |= 0x0010; // XINPUT_GAMEPAD_START
+                        if (XR_SUCCEEDED(xrGetActionStateBoolean(m_session, &gi, &st)) && st.isActive) {
+                            menuPressed = st.currentState != XR_FALSE;
+                        }
                     }
 
-                    // Publish the snapshot for the XInput hook.
-                    std::lock_guard<std::mutex> inLock(m_inputMutex);
-                    m_controllerState = ctrl;
+                    const int configuredMode = GetChordActivationMethod();
+                    const int effectiveMode = (configuredMode == 2 && !rightThumbrestAvailable)
+                        ? 0 : configuredMode;
+                    const bool extraChordActionsEnabled = GetExtraChordActionsEnabled() != 0;
+                    const bool facePressed[4] = {
+                        primaryPressed[0], secondaryPressed[0],
+                        primaryPressed[1], secondaryPressed[1]
+                    };
+                    const uint16_t faceBits[4] = { XB_X, XB_Y, XB_A, XB_B };
+                    constexpr float dpadThreshold = 0.5f;
+                    constexpr float dpadNeutralThreshold = 0.35f;
+                    const int dpadStick = effectiveMode == 0 ? 1 : 0;
+                    const int recenterButton = effectiveMode == 0 ? 2 : 0;
+                    const int overlayButton = effectiveMode == 0 ? 3 : 1;
+                    const bool modifierPressed = effectiveMode == 0 ? stickClicked[0]
+                        : (effectiveMode == 1 ? stickClicked[1] : rightThumbrestTouched);
+                    // The native menu-mode hook covers normal game menus; shared slot 81 is the
+                    // existing world-map fallback. The F10 overlay is intentionally excluded:
+                    // it is not controller-driven and its chord shortcut must remain available.
+                    // Slot 81 is written as uint32 bits in the shared float block, so test for
+                    // nonzero rather than comparing its float interpretation with a threshold.
+                    const bool gameMenuActive = GetMenuMode() != 0 || GetSharedSlot(81) != 0.0f;
+                    const bool thumbModifier = effectiveMode == 0 || effectiveMode == 1;
+                    const bool modifierWasHeld = s_chord.effectiveMode == effectiveMode
+                        && s_chord.modifierHeld;
+                    const bool chordInputAlreadyActive =
+                        std::abs(stickX[dpadStick]) >= dpadNeutralThreshold
+                        || std::abs(stickY[dpadStick]) >= dpadNeutralThreshold
+                        || (effectiveMode == 0
+                            && (std::abs(stickX[0]) >= dpadNeutralThreshold
+                                || std::abs(stickY[0]) >= dpadNeutralThreshold))
+                        || (effectiveMode == 1
+                            && (std::abs(stickX[1]) >= dpadNeutralThreshold
+                                || std::abs(stickY[1]) >= dpadNeutralThreshold))
+                        || menuPressed
+                        || (extraChordActionsEnabled
+                            && (facePressed[recenterButton] || facePressed[overlayButton]));
+                    if (s_chord.effectiveMode != effectiveMode) {
+                        s_chord.effectiveMode = effectiveMode;
+                        s_chord.modifierHeld = modifierPressed;
+                        s_chord.modifierPassthrough = false;
+                        s_chord.modifierDeferred = modifierPressed && thumbModifier && gameMenuActive;
+                        s_chord.chordConsumed = false;
+                        s_chord.dpadArmed = false;
+                        s_chord.deferredTapButton = 0;
+                        s_chord.deferredTapUntilMs = 0;
+                    } else if (modifierPressed) {
+                        if (!s_chord.modifierHeld) {
+                            s_chord.modifierHeld = true;
+                            s_chord.modifierPassthrough = chordInputAlreadyActive;
+                            s_chord.modifierDeferred = thumbModifier && gameMenuActive;
+                            s_chord.chordConsumed = false;
+                            s_chord.dpadArmed = false;
+                            s_chord.deferredTapButton = 0;
+                            s_chord.deferredTapUntilMs = 0;
+                        }
+                    } else if (s_chord.modifierHeld) {
+                        if (s_chord.modifierDeferred && !s_chord.chordConsumed) {
+                            s_chord.deferredTapButton = effectiveMode == 0
+                                ? XB_LEFT_THUMB : XB_RIGHT_THUMB;
+                            s_chord.deferredTapUntilMs = GetTickCount64() + 50;
+                        }
+                        s_chord.modifierHeld = false;
+                        s_chord.modifierPassthrough = false;
+                        s_chord.modifierDeferred = false;
+                        s_chord.chordConsumed = false;
+                        s_chord.dpadArmed = false;
+                    }
+                    const bool chordReady = modifierPressed && modifierWasHeld
+                        && !s_chord.modifierPassthrough;
+
+                    // Gameplay keeps the configured thumb click additive. A press that begins in
+                    // a game menu is deferred until release so a completed chord cannot also fire
+                    // that menu's native L3/R3 action. The other thumb click always passes through.
+                    const bool suppressLeftThumb = effectiveMode == 0 && s_chord.modifierDeferred;
+                    const bool suppressRightThumb = effectiveMode == 1 && s_chord.modifierDeferred;
+                    if (stickClicked[0] && !suppressLeftThumb) ctrl.buttons |= XB_LEFT_THUMB;
+                    if (stickClicked[1] && !suppressRightThumb) ctrl.buttons |= XB_RIGHT_THUMB;
+                    if (s_chord.deferredTapButton != 0) {
+                        if (GetTickCount64() < s_chord.deferredTapUntilMs) {
+                            ctrl.buttons |= s_chord.deferredTapButton;
+                        } else {
+                            s_chord.deferredTapButton = 0;
+                            s_chord.deferredTapUntilMs = 0;
+                        }
+                    }
+                    if (chordReady) {
+                        const float sx = stickX[dpadStick];
+                        const float sy = stickY[dpadStick];
+                        if (!s_chord.dpadArmed
+                            && std::abs(sx) < dpadNeutralThreshold
+                            && std::abs(sy) < dpadNeutralThreshold) {
+                            s_chord.dpadArmed = true;
+                        }
+                        if (s_chord.dpadArmed) {
+                            if (sy > dpadThreshold) {
+                                ctrl.buttons |= XB_DPAD_UP;
+                                s_chord.chordConsumed = true;
+                            }
+                            if (sy < -dpadThreshold) {
+                                ctrl.buttons |= XB_DPAD_DOWN;
+                                s_chord.chordConsumed = true;
+                            }
+                            if (sx < -dpadThreshold) {
+                                ctrl.buttons |= XB_DPAD_LEFT;
+                                s_chord.chordConsumed = true;
+                            }
+                            if (sx > dpadThreshold) {
+                                ctrl.buttons |= XB_DPAD_RIGHT;
+                                s_chord.chordConsumed = true;
+                            }
+                            if (dpadStick == 0) {
+                                ctrl.leftThumbX = 0.0f;
+                                ctrl.leftThumbY = 0.0f;
+                            } else {
+                                ctrl.rightThumbX = 0.0f;
+                                ctrl.rightThumbY = 0.0f;
+                            }
+                        }
+                    }
+
+                    if (menuPressed && !s_chord.menuDown) {
+                        s_chord.menuChorded = chordReady;
+                        if (s_chord.menuChorded) s_chord.chordConsumed = true;
+                    }
+                    if (menuPressed) {
+                        ctrl.buttons |= s_chord.menuChorded ? XB_BACK : XB_START;
+                    } else {
+                        s_chord.menuChorded = false;
+                    }
+                    s_chord.menuDown = menuPressed;
+
+                    for (int button = 0; button < 4; ++button) {
+                        if (!facePressed[button]) s_chord.faceChordLatched[button] = false;
+                    }
+
+                    if (extraChordActionsEnabled && chordReady) {
+                        if (facePressed[recenterButton] && !s_chord.faceWasDown[recenterButton]) {
+                            s_chord.faceChordLatched[recenterButton] = true;
+                            s_chord.chordConsumed = true;
+                            RequestRecenter();
+                        }
+                        if (facePressed[overlayButton] && !s_chord.faceWasDown[overlayButton]) {
+                            s_chord.faceChordLatched[overlayButton] = true;
+                            s_chord.chordConsumed = true;
+                            RequestOverlayToggle();
+                        }
+                    }
+
+                    for (int button = 0; button < 4; ++button) {
+                        if (facePressed[button] && !s_chord.faceChordLatched[button]) {
+                            ctrl.buttons |= faceBits[button];
+                        }
+                        s_chord.faceWasDown[button] = facePressed[button];
+                    }
+                } else {
+                    s_chord = {};
+                    m_rightThumbrestAvailable.store(false, std::memory_order_relaxed);
                 }
+
+                // Always publish a fresh snapshot so disabling gameplay actions cannot
+                // leave a button or axis latched in the XInput merge.
+                std::lock_guard<std::mutex> inLock(m_inputMutex);
+                m_controllerState = ctrl;
             }
 
             // Rotate the head velocity into the same base-recentered frame as the

--- a/src/vr/openxr/openxr_internal.h
+++ b/src/vr/openxr/openxr_internal.h
@@ -57,6 +57,8 @@ extern "C" float GetFlowSmooth();
 extern "C" float GetHmdTrackingSmooth();
 extern "C" float GetHandTrackingSmooth();
 extern "C" int GetInputActionsEnabled();
+extern "C" int GetChordActivationMethod();
+extern "C" int GetExtraChordActionsEnabled();
 extern "C" int GetMonoXQueueWait();
 extern "C" int GetMonoDepthCapture();
 // GPU cross-queue barrier helper (defined in swapchain_hooks.cpp).

--- a/src/vr/openxr/openxr_manager.cpp
+++ b/src/vr/openxr/openxr_manager.cpp
@@ -603,6 +603,8 @@ bool OpenXRManager::Init() {
             makeAction(m_primaryButtonAction,   XR_ACTION_TYPE_BOOLEAN_INPUT,  "primary_button",   "Primary Button (A/X)", true);
             makeAction(m_secondaryButtonAction, XR_ACTION_TYPE_BOOLEAN_INPUT,  "secondary_button", "Secondary Button (B/Y)", true);
             makeAction(m_menuButtonAction,      XR_ACTION_TYPE_BOOLEAN_INPUT,  "menu",             "Menu Button",          false);
+            makeAction(m_rightThumbrestAction,  XR_ACTION_TYPE_BOOLEAN_INPUT,  "right_thumbrest",  "Right Thumbrest",      false);
+            xrStringToPath(m_instance, "/interaction_profiles/oculus/touch_controller", &m_oculusTouchProfilePath);
         }
         Log("OpenXRManager[Input]: gameplay action set %s (xr_input_actions=%d)\n",
             inputActionsEnabled ? "ENABLED" : "DISABLED (pose-only)", (int)inputActionsEnabled);
@@ -665,6 +667,7 @@ bool OpenXRManager::Init() {
             { m_secondaryButtonAction, "/user/hand/left/input/y/click" },
             { m_secondaryButtonAction, "/user/hand/right/input/b/click" },
             { m_menuButtonAction,      "/user/hand/left/input/menu/click" },
+            { m_rightThumbrestAction,  "/user/hand/right/input/thumbrest/touch" },
         });
 
         // -- Valve Index: A/B on both hands, system as menu --
@@ -882,6 +885,8 @@ void OpenXRManager::EndSession() {
     if (m_session == XR_NULL_HANDLE || !m_sessionRunning.load(std::memory_order_relaxed)) return;
     xrEndSession(m_session);
     m_sessionRunning.store(false, std::memory_order_relaxed);
+    m_rightThumbrestProfileKnown.store(false, std::memory_order_relaxed);
+    m_rightThumbrestAvailable.store(false, std::memory_order_relaxed);
     Log("OpenXRManager: Session ended.\n");
 }
 
@@ -902,6 +907,9 @@ void OpenXRManager::PollEvents() {
             } else if (m_sessionState == XR_SESSION_STATE_EXITING || m_sessionState == XR_SESSION_STATE_LOSS_PENDING) {
                 m_stopFrameThread.store(true, std::memory_order_relaxed);
             }
+        } else if (event.type == XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED) {
+            m_rightThumbrestProfileKnown.store(false, std::memory_order_relaxed);
+            RefreshRightThumbrestAvailability();
         } else if (event.type == XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING) {
             // Native OpenXR recenter (user held the home / system button, or used the runtime menu) —
             // the runtime is about to remap "forward" of its tracking space at changed->changeTime.
@@ -915,6 +923,22 @@ void OpenXRManager::PollEvents() {
         }
 
         event = {XR_TYPE_EVENT_DATA_BUFFER};
+    }
+}
+
+void OpenXRManager::RefreshRightThumbrestAvailability() {
+    if (m_session == XR_NULL_HANDLE || m_handPaths[1] == XR_NULL_PATH
+        || m_oculusTouchProfilePath == XR_NULL_PATH) {
+        return;
+    }
+
+    XrInteractionProfileState profile{XR_TYPE_INTERACTION_PROFILE_STATE};
+    if (XR_SUCCEEDED(xrGetCurrentInteractionProfile(m_session, m_handPaths[1], &profile))
+        && profile.interactionProfile != XR_NULL_PATH) {
+        m_rightThumbrestAvailable.store(
+            profile.interactionProfile == m_oculusTouchProfilePath,
+            std::memory_order_relaxed);
+        m_rightThumbrestProfileKnown.store(true, std::memory_order_relaxed);
     }
 }
 
@@ -1618,6 +1642,8 @@ void OpenXRManager::Shutdown() {
     }
     m_initialized = false;
     m_poseValid.store(false, std::memory_order_relaxed);
+    m_rightThumbrestProfileKnown.store(false, std::memory_order_relaxed);
+    m_rightThumbrestAvailable.store(false, std::memory_order_relaxed);
     {
         std::lock_guard<std::mutex> renderLock(m_renderPoseMutex);
         m_basePoseSet = false;

--- a/src/vr/openxr/openxr_manager.h
+++ b/src/vr/openxr/openxr_manager.h
@@ -667,10 +667,12 @@ public:
 
     bool IsInitialized() const { return m_initialized; }
     bool IsSessionRunning() const { return m_sessionRunning.load(std::memory_order_relaxed); }
+    bool IsRightThumbrestAvailable() const { return m_rightThumbrestAvailable.load(std::memory_order_relaxed); }
 
 private:
     static DWORD WINAPI FrameThreadThunk(LPVOID param);
     DWORD FrameThreadMain();
+    void RefreshRightThumbrestAvailability();
     // Dedicated submit thread: parks while the inline Present pump owns the loop, and
     // takes the loop over whenever UseThreadedSubmit() is true (SteamVR, or
     // ThreadedMonoSubmit) so the blocking fence/swapchain waits never run on the
@@ -735,6 +737,10 @@ private:
     XrAction m_primaryButtonAction = XR_NULL_HANDLE;     // Bool, per hand (X / A)
     XrAction m_secondaryButtonAction = XR_NULL_HANDLE;   // Bool, per hand (Y / B)
     XrAction m_menuButtonAction = XR_NULL_HANDLE;        // Bool, left only on Touch
+    XrAction m_rightThumbrestAction = XR_NULL_HANDLE;    // Bool, Oculus Touch right thumbrest touch
+    XrPath m_oculusTouchProfilePath = XR_NULL_PATH;
+    std::atomic<bool> m_rightThumbrestProfileKnown{false};
+    std::atomic<bool> m_rightThumbrestAvailable{false};
     XrPath m_handPaths[2] = { XR_NULL_PATH, XR_NULL_PATH };
     XrSpace m_handSpaces[2] = { XR_NULL_HANDLE, XR_NULL_HANDLE };
     // Latest controller snapshot, owned by the frame thread.

--- a/src/vr/overlay/imgui_overlay.cpp
+++ b/src/vr/overlay/imgui_overlay.cpp
@@ -1513,10 +1513,22 @@ bool DrawLiveControls(LiveControlsUiState& state) {
             }
 
             ImGui::Separator();
-            ImGui::TextUnformatted("Default binding (CP2077 native gamepad):");
-            ImGui::BulletText("Left stick   - walk / jog (push FULL forward = sprint / L3)");
+            ImGui::TextUnformatted("Stick edge actions");
+            changed |= CheckboxInt("Full-stick Sprint / Crouch", &state.xrFullStickSprintCrouch);
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Send L3 when the left stick is fully forward and R3 when the\n"
+                                  "right stick is fully down. Off keeps both sticks as analog input only.");
+            }
+
+            ImGui::Separator();
+            ImGui::TextUnformatted("Other bindings (CP2077 native gamepad):");
+            if (state.xrFullStickSprintCrouch != 0)
+                ImGui::BulletText("Left stick   - walk / jog (push FULL forward = sprint / L3)");
+            else
+                ImGui::BulletText("Left stick   - walk / jog");
             ImGui::BulletText("Right stick X - turn camera (Y = pitch unless Disable Mouse Y is on)");
-            ImGui::BulletText("Right stick FULL down - crouch (R3)");
+            if (state.xrFullStickSprintCrouch != 0)
+                ImGui::BulletText("Right stick FULL down - crouch (R3)");
             ImGui::BulletText("Right A      - JUMP");
             ImGui::BulletText("Right B      - dodge");
             ImGui::BulletText("Left  X      - reload / interact");

--- a/src/vr/overlay/imgui_overlay.cpp
+++ b/src/vr/overlay/imgui_overlay.cpp
@@ -3,6 +3,7 @@
 #include "openxr_manager.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cfloat>
 #include <cmath>
 #include <cstdio>
@@ -105,6 +106,7 @@ HWND g_hwnd = nullptr;
 WNDPROC g_originalWndProc = nullptr;
 bool g_imguiInitialized = false;
 bool g_menuVisible = false;
+std::atomic<uint32_t> g_menuToggleRequests{0};
 bool g_drawHandLocator = false;
 bool g_drawHandProxy3D = false;
 bool g_drawHandDebugAxes = false;
@@ -1155,6 +1157,14 @@ void ReleaseGameMouseCapture() {
     }
 }
 
+void ToggleOverlayMenu() {
+    g_menuVisible = !g_menuVisible;
+    if (g_menuVisible) {
+        ReleaseGameMouseCapture();
+    }
+    if (g_verboseLog) Log("ImGui overlay %s.\n", g_menuVisible ? "shown" : "hidden");
+}
+
 void UpdateImGuiMouseFromCursor(HWND hwnd, float backbufferWidth, float backbufferHeight) {
     ImGuiIO& io = ImGui::GetIO();
 
@@ -1472,6 +1482,50 @@ bool DrawLiveControls(LiveControlsUiState& state) {
             }
 
             ImGui::Separator();
+            ImGui::TextUnformatted("Emulate D-pad and Additional Controls");
+            ImGui::TextUnformatted("Chord Activation Method");
+            changed |= ImGui::RadioButton("L3 button - left thumbstick", &state.xrChordActivation, 0);
+            changed |= ImGui::RadioButton("R3 button - right thumbstick", &state.xrChordActivation, 1);
+            const bool thumbrestAvailable = OpenXRManager::Get().IsRightThumbrestAvailable();
+            changed |= ImGui::RadioButton(
+                thumbrestAvailable ? "Right thumbrest" : "Right thumbrest (unavailable)",
+                &state.xrChordActivation,
+                2);
+            if (!thumbrestAvailable && state.xrChordActivation == 2) {
+                ImGui::TextDisabled("Using L3 button - left thumbstick until right thumbrest is available.");
+            }
+            changed |= CheckboxInt("Extra Chord Actions", &state.xrExtraChordActions);
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Enable extra chord actions for VR Recenter and the F10 Menu.\n"
+                                  "D-pad emulation and Back/Select remain available when this option is disabled.");
+            }
+            ImGui::TextDisabled("Current binding:");
+            const int effectiveChord = (state.xrChordActivation == 2 && !thumbrestAvailable)
+                ? 0 : state.xrChordActivation;
+            if (effectiveChord == 0) {
+                ImGui::BulletText("Hold left thumb click: right stick = D-pad, left Menu = Back/Select");
+                if (state.xrExtraChordActions != 0)
+                    ImGui::BulletText("Extra actions: A = Recenter, B = F10 Menu");
+                else
+                    ImGui::BulletText("Extra actions: disabled");
+                ImGui::BulletText("Thumb clicks: left = L3, right = R3");
+            } else if (effectiveChord == 1) {
+                ImGui::BulletText("Hold right thumb click: left stick = D-pad, left Menu = Back/Select");
+                if (state.xrExtraChordActions != 0)
+                    ImGui::BulletText("Extra actions: X = Recenter, Y = F10 Menu");
+                else
+                    ImGui::BulletText("Extra actions: disabled");
+                ImGui::BulletText("Thumb clicks: left = L3, right = R3");
+            } else {
+                ImGui::BulletText("Touch right thumbrest: left stick = D-pad, left Menu = Back/Select");
+                if (state.xrExtraChordActions != 0)
+                    ImGui::BulletText("Extra actions: X = Recenter, Y = F10 Menu");
+                else
+                    ImGui::BulletText("Extra actions: disabled");
+                ImGui::BulletText("Thumb clicks: left = L3, right = R3");
+            }
+
+            ImGui::Separator();
             ImGui::TextUnformatted("Weapon holsters (reach + right grip)");
             changed |= CheckboxInt("Immersive holsters", &state.xrImmersiveHolsters);
             if (ImGui::IsItemHovered()) {
@@ -1545,13 +1599,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
             ImGui::BulletText("Left  Y      - weapon switch");
             ImGui::BulletText("Right trigger - fire    | Left trigger - aim");
             ImGui::BulletText("Right grip    - holster equip / unequip | Left grip - crouch (shoulder)");
-            ImGui::BulletText("Left  thumb click - sprint (L3) | Right thumb click - crouch (R3)");
-            ImGui::BulletText("Left  menu button - pause menu");
-            ImGui::BulletText("DPAD - Emulation");
-            ImGui::BulletText("Right GRIP + RightThum UP | DPAD UP");
-            ImGui::BulletText("Right GRIP + RightThum DOWN | DPAD DOWN");
-            ImGui::BulletText("Right GRIP + RightThum LEFT | DPAD LEFT");
-            ImGui::BulletText("Right GRIP + RightThum RIGHT | DPAD RIGHT");
+            ImGui::BulletText("Left menu button - Start / pause menu (without chord)");
 
             ImGui::TextWrapped("Buttons follow each runtime's interaction profile (Touch / Index / "
                                "Vive / WMR). Customize the actual key bindings in the game's "
@@ -1800,11 +1848,7 @@ LRESULT CALLBACK OverlayWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
     // 2. Handle menu toggle
     if ((msg == WM_KEYUP || msg == WM_SYSKEYUP) && (wParam == VK_F10 || wParam == VK_INSERT)) {
-        g_menuVisible = !g_menuVisible;
-        if (g_menuVisible) {
-            ReleaseGameMouseCapture();
-        }
-        if (g_verboseLog) Log("ImGui overlay %s.\n", g_menuVisible ? "shown" : "hidden");
+        ToggleOverlayMenu();
         return 0;
     }
 
@@ -1820,6 +1864,10 @@ LRESULT CALLBACK OverlayWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
     return g_originalWndProc ? CallWindowProcA(g_originalWndProc, hwnd, msg, wParam, lParam) : DefWindowProcA(hwnd, msg, wParam, lParam);
 }
+}
+
+extern "C" void RequestOverlayToggle() {
+    g_menuToggleRequests.fetch_add(1, std::memory_order_release);
 }
 
 void OverlaySetDeviceAndQueue(ID3D12Device* device, ID3D12CommandQueue* queue) {
@@ -1853,6 +1901,11 @@ void OverlaySetWindow(HWND hwnd) {
 
 void OverlayRender(IDXGISwapChain* swapChain) {
     if (!EnsureImGui(swapChain)) return;
+
+    const uint32_t toggleRequests = g_menuToggleRequests.exchange(0, std::memory_order_acq_rel);
+    if ((toggleRequests & 1u) != 0u) {
+        ToggleOverlayMenu();
+    }
 
     DXGI_SWAP_CHAIN_DESC desc{};
     if (FAILED(swapChain->GetDesc(&desc))) return;

--- a/src/vr/overlay/imgui_overlay.cpp
+++ b/src/vr/overlay/imgui_overlay.cpp
@@ -1485,6 +1485,16 @@ bool DrawLiveControls(LiveControlsUiState& state) {
             }
 
             ImGui::Separator();
+            ImGui::TextUnformatted("Vehicle controls");
+            changed |= CheckboxInt("Swap Triggers / Grips While Driving", &state.xrSwapTriggersGripsDriving);
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("While driving, use the VR controller triggers as LB/RB and the\n"
+                                  "analog grips as LT/RT. This keeps Fire on the right trigger\n"
+                                  "while mapping brake and accelerate to the grips. Physical\n"
+                                  "gamepad inputs are not remapped. Off preserves the original controls.");
+            }
+
+            ImGui::Separator();
             ImGui::TextUnformatted("Locomotion direction");
             const char* moveSrcNames[] = { "Game (camera)", "HMD (head)", "Left hand", "Right hand" };
             int moveSrc = state.xrMovementSource;

--- a/src/vr/overlay/imgui_overlay.h
+++ b/src/vr/overlay/imgui_overlay.h
@@ -9,3 +9,4 @@ void OverlaySetWindow(HWND hwnd);
 void OverlayRender(IDXGISwapChain* swapChain);
 void OverlayInvalidateSwapchainResources();
 bool OverlayIsVisible();
+extern "C" void RequestOverlayToggle();

--- a/src/vr/overlay/live_controls_ui.h
+++ b/src/vr/overlay/live_controls_ui.h
@@ -95,6 +95,7 @@ struct LiveControlsUiState {
     // OpenXR binding or XInput entry-point patch can't keep CP2077 from booting.
     int xrXInputInstall;
     int xrInputActions;
+    int xrFullStickSprintCrouch;
     // Mono submit safety flags. Defaults 0 keep CP2077 mono mode from hanging on
     // the menu (see cybervrport-controller-bindings memory for the trace).
     int xrMonoXQueueWait;

--- a/src/vr/overlay/live_controls_ui.h
+++ b/src/vr/overlay/live_controls_ui.h
@@ -95,6 +95,13 @@ struct LiveControlsUiState {
     // OpenXR binding or XInput entry-point patch can't keep CP2077 from booting.
     int xrXInputInstall;
     int xrInputActions;
+    // Controller chord layout. 0 = left L3 + right stick D-pad (original),
+    // 1 = right R3 + left stick D-pad, 2 = right
+    // thumbrest + left stick D-pad.
+    int xrChordActivation;
+    // Optional chord actions only: VR recenter and F10 overlay toggle. D-pad
+    // and Back/Select remain active regardless of this value.
+    int xrExtraChordActions;
     int xrFullStickSprintCrouch;
     // In vehicles only, map VR triggers to LB/RB and analog grips to LT/RT.
     // Physical XInput controller state is never remapped.

--- a/src/vr/overlay/live_controls_ui.h
+++ b/src/vr/overlay/live_controls_ui.h
@@ -96,6 +96,9 @@ struct LiveControlsUiState {
     int xrXInputInstall;
     int xrInputActions;
     int xrFullStickSprintCrouch;
+    // In vehicles only, map VR triggers to LB/RB and analog grips to LT/RT.
+    // Physical XInput controller state is never remapped.
+    int xrSwapTriggersGripsDriving;
     // Mono submit safety flags. Defaults 0 keep CP2077 mono mode from hanging on
     // the menu (see cybervrport-controller-bindings memory for the trace).
     int xrMonoXQueueWait;


### PR DESCRIPTION
## Summary

This PR fixes several controller issues in v0.1.1 that affect normal gameplay, including the broken
`Disable Mouse Y (Pitch)` option, the missing RB input, visual holster conflicts, and vehicle
controls. It also makes the existing full-stick Sprint / Crouch actions configurable and adds a
chord system that provides complete controller-only access to the remaining actions.

The new chord feature is intentionally isolated in the final commit because it extends the original
functionality rather than fixing an existing behavior. This lets the first three gameplay fixes be
reviewed and merged independently if the additional feature is outside the desired upstream scope.

For complete controller setup and usage instructions, see the
[README in this fork](https://github.com/dabinn/cyberpunk-vr-port/blob/main/README.md).

## Changes

### 1. Fix `Disable Mouse Y (Pitch)`

- Restores mouse and right-stick pitch when the option is disabled.
- Works both armed and unarmed through the same native pitch path.
- Keeps the existing HMD-only vertical look when the option is enabled.
- Snap Turn continues to affect horizontal turning only; vertical input remains analog.

Fixes #25.

### 2. Add a full-stick Sprint / Crouch toggle

- Adds a persistent Controls option for the existing full-forward Sprint and full-down Crouch
  actions.
- Enabled by default to preserve the original v0.1.1 behavior.
- Disabling it leaves both thumbsticks as analog input only, which allows the full right-stick range
  to be used when vertical stick look is enabled.

### 3. Make RB coexist with visual holsters and improve vehicle controls

- Right Grip sends RB outside the existing shoulder and hip holster zones.
- Grip presses that start inside a holster zone retain the original visual holster behavior.
- Each press is latched to one route until release, preventing RB and holster actions from firing
  together when the hand crosses a zone boundary.
- Visual holster input is suppressed while the player is mounted in a vehicle, in both first- and
  third-person vehicle cameras.
- Adds an optional `Swap Triggers / Grips While Driving` setting:
  - VR triggers become LB / RB.
  - Analog VR grips become LT / RT.
  - This keeps Fire on the right trigger while using the grips for brake and acceleration.
- Only VR-injected input is remapped. A physical XInput controller remains unchanged.
- The vehicle swap is disabled by default.

The existing CET holster thresholds and zone priority are preserved. The holster classifier publishes
only the selected route; no duplicate body-zone implementation was added to the native input layer.

### 4. Add configurable VR controller chord controls

- Supports three activation methods:
  - L3 / left thumbstick click — original and default behavior.
  - R3 / right thumbstick click.
  - Right thumbrest touch, when supported by the active OpenXR interaction profile.
- Keeps D-pad emulation and Back / Select available through the chord.
- Adds VR Recenter and F10 Menu shortcuts behind the enabled-by-default `Extra Chord Actions`
  setting.
- Existing F7, F10 and Insert keyboard hotkeys remain available.
- Requires the chord modifier to be active before the combined input, preventing held sticks or
  buttons from being reinterpreted retroactively.
- Preserves normal L3 / R3 output, Sprint and camera turning whenever chord recognition is rejected.

Because this is a new feature rather than a correction to existing behavior, it is isolated in the
final commit so its scope can be reviewed independently from the first three fixes.

## Defaults and compatibility

- Existing behavior is preserved by default wherever practical:
  - Chord activation: L3.
  - Full-stick Sprint / Crouch: enabled.
  - Vehicle Trigger / Grip swap: disabled.
- Physical gamepad input is never remapped.
- Existing keyboard hotkeys remain available.
- The visual holster implementation and its current distance thresholds are retained.


## Validation

- Verified in game with armed and unarmed pitch control.
- Verified L3, R3 and right-thumbrest chord activation modes.
- Verified normal Sprint and camera turning while chord recognition is rejected.
- Verified native game-menu chords do not also trigger L3 / R3, while gameplay retains held
  thumb-click output and Sprint.
- Verified the full-stick Sprint / Crouch option.
- Verified RB and visual holster coexistence.
- Verified vehicle holster suppression and the optional Trigger / Grip swap.
- Verified first- and third-person vehicle camera states use the same mounted-player behavior.
- `CyberpunkVR_Stereo` builds successfully in `Release`.
- `CyberpunkVR_Hands` builds successfully in `RelWithDebInfo`.
- The first three commits were also built successfully without the final chord commit.

## Commit structure

1. `fix(camera): fix Disable Mouse Y option - restore mouse and right-stick pitch when the option is disabled`
2. `feat(input): add full-stick sprint and crouch toggle`
3. `feat(input): support RB/holster routing and vehicle controls`
4. `feat(input): add configurable VR controller chord controls`
