### PR TITLE
Add additional adjustable phone-related HUD elements to F10 menu

### DIFF
--- a/mods/cet/CyberpunkVRPort_HUD/init.lua
+++ b/mods/cet/CyberpunkVRPort_HUD/init.lua
@@ -6,6 +6,10 @@ local hudLive = {
     capturedRoot = nil,
     capturedWidgetCount = 0,
     originalMetrics = {},
+    messengerController = nil,
+    messengerLastX = nil,
+    messengerLastY = nil,
+    messengerLastScale = nil,
     pollTimer = 0.0,
     pollInterval = 0.10,
     iniPath = 'vrport.ini',
@@ -32,6 +36,21 @@ local function cloneDefaultLayout()
         phone = 0.0,
         phoneY = 0.0,
         phoneScale = 1.00,
+        holocall = 600.0,
+        holocallY = 600.0,
+        holocallScale = 2.00,
+        incomingCall = 600.0,
+        incomingCallY = 1050.0,
+        incomingCallScale = 2.00,
+        phoneMessage = 600.0,
+        phoneMessageY = 800.0,
+        phoneMessageScale = 1.80,
+        messageReader = 600.0,
+        messageReaderY = 500.0,
+        messageReaderScale = 1.40,
+        messengerMenu = 1150.0,
+        messengerMenuY = 500.0,
+        messengerMenuScale = 1.50,
         topLeftAlerts = 0.0,
         topLeftAlertsY = 0.0,
         topLeftAlertsScale = 1.00,
@@ -67,11 +86,11 @@ local function clampOffset(value)
     if type(value) ~= 'number' then
         return 0.0
     end
-    if value < -1200.0 then
-        return -1200.0
+    if value < -2400.0 then
+        return -2400.0
     end
-    if value > 1200.0 then
-        return 1200.0
+    if value > 2400.0 then
+        return 2400.0
     end
     return value
 end
@@ -150,6 +169,21 @@ local function readLayoutText(path)
         xr_hud_phone = 'phone',
         xr_hud_phone_y = 'phoneY',
         xr_hud_phone_scale = 'phoneScale',
+        xr_hud_holocall = 'holocall',
+        xr_hud_holocall_y = 'holocallY',
+        xr_hud_holocall_scale = 'holocallScale',
+        xr_hud_incoming_call = 'incomingCall',
+        xr_hud_incoming_call_y = 'incomingCallY',
+        xr_hud_incoming_call_scale = 'incomingCallScale',
+        xr_hud_phone_message = 'phoneMessage',
+        xr_hud_phone_message_y = 'phoneMessageY',
+        xr_hud_phone_message_scale = 'phoneMessageScale',
+        xr_hud_message_reader = 'messageReader',
+        xr_hud_message_reader_y = 'messageReaderY',
+        xr_hud_message_reader_scale = 'messageReaderScale',
+        xr_hud_messenger = 'messengerMenu',
+        xr_hud_messenger_y = 'messengerMenuY',
+        xr_hud_messenger_scale = 'messengerMenuScale',
         xr_hud_top_left_alerts = 'topLeftAlerts',
         xr_hud_top_left_alerts_y = 'topLeftAlertsY',
         xr_hud_top_left_alerts_scale = 'topLeftAlertsScale',
@@ -375,6 +409,14 @@ local function getLayoutValueForItem(item)
         return layout.minimapQuest, layout.minimapQuestY, layout.minimapQuestScale
     elseif item.name == 'TopLeftMain' or item.name == 'songbird_phone' then
         return layout.phone, layout.phoneY, layout.phoneScale
+    elseif item.name == 'VRPortHolocall' then
+        return layout.holocall, layout.holocallY, layout.holocallScale
+    elseif item.name == 'VRPortIncomingCall' then
+        return layout.incomingCall, layout.incomingCallY, layout.incomingCallScale
+    elseif item.name == 'VRPortPhoneMessage' then
+        return layout.phoneMessage, layout.phoneMessageY, layout.phoneMessageScale
+    elseif item.name == 'VRPortMessageReader' then
+        return layout.messageReader, layout.messageReaderY, layout.messageReaderScale
     elseif item.name == 'zone alert notification' or item.name == 'militech warning' or item.name == 'hud_courier_bar' or item.name == 'driver_combat_hud' or item.name == 'staminabar' then
         return layout.topLeftAlerts, layout.topLeftAlertsY, layout.topLeftAlertsScale
     elseif item.name == 'HUDMiddleWidget' and item.anchor == inkEAnchor.TopLeft then
@@ -462,6 +504,17 @@ local function applyInsetToCapturedWidgets(root, force)
                 left = left + valueX
                 top = top + valueY
                 adjusted = true
+            elseif item.name == 'VRPortHolocall' or
+                item.name == 'VRPortIncomingCall' or
+                item.name == 'VRPortPhoneMessage' or
+                item.name == 'VRPortMessageReader' then
+                -- These are VR-port-owned top-level slots, so their values are
+                -- absolute layout coordinates rather than offsets from a stock
+                -- game margin. Scale remains consistent with the F10 convention:
+                -- 2.00 = full original size.
+                left = valueX
+                top = valueY
+                adjusted = true
             elseif isTopLeftAlertsItem(item) then
                 left = left + valueX
                 top = top + valueY
@@ -514,12 +567,55 @@ local function applyInsetToCapturedWidgets(root, force)
 
             if adjusted then
                 pcall(function()
-                    item.widget:SetScale(Vector2.new({ X = item.scaleX * appliedScale, Y = item.scaleY * appliedScale }))
+                    local scaleX = item.scaleX * appliedScale
+                    local scaleY = item.scaleY * appliedScale
+                    if item.name == 'VRPortHolocall' or
+                        item.name == 'VRPortIncomingCall' or
+                        item.name == 'VRPortPhoneMessage' or
+                        item.name == 'VRPortMessageReader' then
+                        scaleX = appliedScale
+                        scaleY = appliedScale
+                    end
+                    item.widget:SetScale(Vector2.new({ X = scaleX, Y = scaleY }))
                     item.widget:SetMargin(inkMargin.new({ left = left, top = top, right = right, bottom = bottom }))
                 end)
             end
         end
         ::continue::
+    end
+end
+
+local function applyMessengerLayout(force)
+    local controller = hudLive.messengerController
+    if controller == nil then
+        return
+    end
+
+    local layout = hudLive.layout or cloneDefaultLayout()
+    local x = layout.messengerMenu
+    local y = layout.messengerMenuY
+    local scale = layout.messengerMenuScale
+    if not force and hudLive.messengerLastX ~= nil
+        and math.abs(hudLive.messengerLastX - x) < 0.0005
+        and math.abs(hudLive.messengerLastY - y) < 0.0005
+        and math.abs(hudLive.messengerLastScale - scale) < 0.0005 then
+        return
+    end
+
+    local ok = pcall(function()
+        controller:VrApplyMessengerLayout(x, y, scale)
+    end)
+    if ok then
+        hudLive.messengerLastX = x
+        hudLive.messengerLastY = y
+        hudLive.messengerLastScale = scale
+        logLine(string.format('[CyberpunkVRPort_HUD] applied Messenger layout (%.1f, %.1f, %.2f)', x, y, scale))
+    else
+        hudLive.messengerController = nil
+        hudLive.messengerLastX = nil
+        hudLive.messengerLastY = nil
+        hudLive.messengerLastScale = nil
+        logLine('[CyberpunkVRPort_HUD] Messenger layout bridge failed; clearing cached controller')
     end
 end
 
@@ -685,13 +781,28 @@ local function refreshScale(force)
     end
 
     if changed then
-        logLine(string.format('[CyberpunkVRPort_HUD] layout changed minimapQuest=(%.1f, %.1f, %.2f) phone=(%.1f, %.1f, %.2f) topRight=(%.1f, %.1f, %.2f) bottomLeft=(%.1f, %.1f, %.2f) bottomRight=(%.1f, %.1f, %.2f)',
+        logLine(string.format('[CyberpunkVRPort_HUD] layout changed minimapQuest=(%.1f, %.1f, %.2f) phone=(%.1f, %.1f, %.2f) holocall=(%.1f, %.1f, %.2f) incomingCall=(%.1f, %.1f, %.2f) phoneMessage=(%.1f, %.1f, %.2f) messageReader=(%.1f, %.1f, %.2f) messenger=(%.1f, %.1f, %.2f) topRight=(%.1f, %.1f, %.2f) bottomLeft=(%.1f, %.1f, %.2f) bottomRight=(%.1f, %.1f, %.2f)',
             nextLayout.minimapQuest,
             nextLayout.minimapQuestY,
             nextLayout.minimapQuestScale,
             nextLayout.phone,
             nextLayout.phoneY,
             nextLayout.phoneScale,
+            nextLayout.holocall,
+            nextLayout.holocallY,
+            nextLayout.holocallScale,
+            nextLayout.incomingCall,
+            nextLayout.incomingCallY,
+            nextLayout.incomingCallScale,
+            nextLayout.phoneMessage,
+            nextLayout.phoneMessageY,
+            nextLayout.phoneMessageScale,
+            nextLayout.messageReader,
+            nextLayout.messageReaderY,
+            nextLayout.messageReaderScale,
+            nextLayout.messengerMenu,
+            nextLayout.messengerMenuY,
+            nextLayout.messengerMenuScale,
             nextLayout.topRight,
             nextLayout.topRightY,
             nextLayout.topRightScale,
@@ -710,6 +821,7 @@ local function refreshScale(force)
         -- re-applies the widget whose value actually changed; a root re-resolve
         -- (force=true) re-applies the whole HUD.
         applyScale(force)
+        applyMessengerLayout(force)
     end
 end
 
@@ -735,6 +847,14 @@ registerForEvent('onInit', function()
         hudLive.capturedWidgetCount = 0
         hudLive.rootResolvedLogged = false
         applyScale(true)
+    end)
+
+    ObserveAfter('PhoneDialerLogicController', 'OnInitialize', function(this)
+        hudLive.messengerController = this
+        hudLive.messengerLastX = nil
+        hudLive.messengerLastY = nil
+        hudLive.messengerLastScale = nil
+        applyMessengerLayout(true)
     end)
 
     ObserveAfter('MinimapContainerController', 'OnInitialize', function(this)

--- a/mods/redscript/CyberpunkVRPort_HUD/vrport_phone_surfaces.reds
+++ b/mods/redscript/CyberpunkVRPort_HUD/vrport_phone_surfaces.reds
@@ -1,0 +1,184 @@
+// CyberpunkVRPort — phone HUD surfaces.
+//
+// These controllers are not children of the stable HUD regions exposed by the
+// base game, so the CET HUD layout pass cannot address them directly. Reparent
+// each transient surface into a named top-level slot under the existing VR HUD
+// Root. CyberpunkVRPort_HUD/init.lua owns the slot geometry and reads it from
+// hud_layout.ini, just like the other F10 HUD controls.
+
+module CyberpunkVRPort.Hud
+
+@if(ModuleExists("Codeware"))
+func VrPhoneHudRoot() -> ref<inkCompoundWidget> {
+  let inkSystem: ref<inkSystem> = GameInstance.GetInkSystem();
+  if !IsDefined(inkSystem) {
+    return null;
+  }
+
+  let layer: ref<inkLayerWrapper> = inkSystem.GetLayer(n"inkHUDLayer");
+  if !IsDefined(layer) {
+    return null;
+  }
+
+  let window: ref<inkCompoundWidget> = layer.GetVirtualWindow();
+  if !IsDefined(window) {
+    return null;
+  }
+
+  let root: ref<inkCompoundWidget> = window.GetWidgetByPathName(n"Root") as inkCompoundWidget;
+  if IsDefined(root) {
+    return root;
+  }
+  return window;
+}
+
+@if(ModuleExists("Codeware"))
+func VrCreatePhoneHudSlot(
+  parent: ref<inkCompoundWidget>,
+  slotName: CName,
+  x: Float,
+  y: Float,
+  scale: Float,
+  index: Int32
+) -> ref<inkCanvas> {
+  // Keep the slot object stable across repeated calls/messages. The CET HUD
+  // runtime caches top-level widget references and detects additions by child
+  // count; replacing a slot with another of the same name and count would leave
+  // that cache pointing at the retired widget.
+  let existing: ref<inkCanvas> = parent.GetWidgetByPathName(slotName) as inkCanvas;
+  if IsDefined(existing) {
+    return existing;
+  }
+
+  let slot: ref<inkCanvas> = new inkCanvas();
+  slot.SetName(slotName);
+  slot.SetFitToContent(true);
+  slot.SetInteractive(false);
+  slot.SetAffectsLayoutWhenHidden(false);
+  slot.SetAnchor(inkEAnchor.TopLeft);
+  slot.SetAnchorPoint(Vector2(0.0, 0.0));
+  slot.SetMargin(inkMargin(x, y, 0.0, 0.0));
+  slot.SetScale(Vector2(scale, scale));
+  slot.Reparent(parent, index);
+  return slot;
+}
+
+@if(ModuleExists("Codeware"))
+func VrAttachPhoneHudSurface(target: ref<inkCompoundWidget>, slot: ref<inkCanvas>) -> Void {
+  if !IsDefined(target) || !IsDefined(slot) {
+    return;
+  }
+
+  target.SetAnchor(inkEAnchor.TopLeft);
+  target.SetAnchorPoint(Vector2(0.0, 0.0));
+  target.SetMargin(inkMargin(0.0, 0.0, 0.0, 0.0));
+  target.SetScale(Vector2(1.0, 1.0));
+  target.Reparent(slot);
+}
+
+// Active caller portrait/status panel. 600/600/1.00 is headset-validated.
+@if(ModuleExists("Codeware"))
+@wrapMethod(HoloAudioCallLogicController)
+protected cb func OnInitialize() -> Bool {
+  let result: Bool = wrappedMethod();
+  let parent: ref<inkCompoundWidget> = VrPhoneHudRoot();
+  if IsDefined(parent) {
+    let slot: ref<inkCanvas> = VrCreatePhoneHudSlot(
+      parent,
+      n"VRPortHolocall",
+      600.0,
+      600.0,
+      1.0,
+      63
+    );
+    VrAttachPhoneHudSurface(this.GetRootCompoundWidget(), slot);
+  }
+  return result;
+}
+
+// Ringing-call accept/decline prompt. 600/1050/1.00 is headset-validated.
+@if(ModuleExists("Codeware"))
+@wrapMethod(IncomingCallLogicController)
+protected cb func OnInitialize() -> Bool {
+  let result: Bool = wrappedMethod();
+  let parent: ref<inkCompoundWidget> = VrPhoneHudRoot();
+  if IsDefined(parent) {
+    let slot: ref<inkCanvas> = VrCreatePhoneHudSlot(
+      parent,
+      n"VRPortIncomingCall",
+      600.0,
+      1050.0,
+      1.0,
+      64
+    );
+    VrAttachPhoneHudSurface(this.GetRootCompoundWidget(), slot);
+  }
+  return result;
+}
+
+// Brief incoming SMS card created by JournalNotificationQueue. The hook target
+// was live-validated at 600/600/1.00; 600/800/0.90 is the refined default.
+@if(ModuleExists("Codeware"))
+@wrapMethod(MessengerNotification)
+protected cb func OnInitialize() -> Bool {
+  let result: Bool = wrappedMethod();
+  let parent: ref<inkCompoundWidget> = VrPhoneHudRoot();
+  if IsDefined(parent) {
+    let slot: ref<inkCanvas> = VrCreatePhoneHudSlot(
+      parent,
+      n"VRPortPhoneMessage",
+      600.0,
+      800.0,
+      0.9,
+      65
+    );
+    VrAttachPhoneHudSurface(this.GetRootCompoundWidget(), slot);
+  }
+  return result;
+}
+
+// Expanded READ MESSAGE modal. Live testing validated this controller and the
+// top-level slot transform at 600/350/0.75. The integrated default lowers it
+// and trims it slightly to 600/500/0.70; F10 keeps X/Y/Size independent.
+@if(ModuleExists("Codeware"))
+@wrapMethod(PhoneMessagePopupGameController)
+protected cb func OnInitialize() -> Bool {
+  let result: Bool = wrappedMethod();
+  let parent: ref<inkCompoundWidget> = VrPhoneHudRoot();
+  if IsDefined(parent) {
+    let slot: ref<inkCanvas> = VrCreatePhoneHudSlot(
+      parent,
+      n"VRPortMessageReader",
+      600.0,
+      500.0,
+      0.7,
+      66
+    );
+    VrAttachPhoneHudSurface(this.GetRootCompoundWidget(), slot);
+  }
+  return result;
+}
+
+// The complete Messages / Contacts browser is owned by the phone-dialer root.
+// Live headset evidence validated one absolute margin and scale on this exact
+// native root; no nested controller or child-reference transform is used.
+@if(ModuleExists("Codeware"))
+@addMethod(PhoneDialerLogicController)
+public func VrApplyMessengerLayout(x: Float, y: Float, size: Float) -> Void {
+  let rootWidget: ref<inkWidget> = this.GetRootWidget();
+  let appliedScale: Float = size * 0.5;
+  if IsDefined(rootWidget) {
+    rootWidget.SetMargin(inkMargin(x, y, 0.0, 0.0));
+    rootWidget.SetScale(Vector2(appliedScale, appliedScale));
+  }
+}
+
+@if(ModuleExists("Codeware"))
+@wrapMethod(PhoneDialerLogicController)
+protected cb func OnInitialize() -> Bool {
+  let result: Bool = wrappedMethod();
+  // Headset-validated phone-dialer root values. CET re-applies persisted F10
+  // values immediately after initialization when its HUD runtime is available.
+  this.VrApplyMessengerLayout(1150.0, 500.0, 1.5);
+  return result;
+}

--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -39,15 +39,19 @@ static FILETIME g_lastVrikRecenterWrite = {};
 static const int kNoRecenterBaseline = -2000000000;
 static int g_lastVrikRecenterCounter = kNoRecenterBaseline;
 
-// HUD placement values = the 34 contiguous floats in LiveControlsUiState
+// HUD placement values = the 49 contiguous floats in LiveControlsUiState
 // (xrHudScale .. xrHudOxygenBar). The CET HUD mod (CyberpunkVRPort_HUD)
 // polls hud_layout.ini for these xr_hud_* keys; g_liveControls has no HUD
 // fields, so we keep the last overlay-set values here and (de)serialize them.
 // Order MUST match the struct field order so a single memcpy bridges them.
-static const int kHudFieldCount = 34;
-static const char* const kHudKeys[kHudFieldCount] = {
+static const char* const kHudKeys[] = {
     "xr_hud_scale", "xr_hud_scale_y", "xr_hud_scale_scale",
     "xr_hud_phone", "xr_hud_phone_y", "xr_hud_phone_scale",
+    "xr_hud_holocall", "xr_hud_holocall_y", "xr_hud_holocall_scale",
+    "xr_hud_incoming_call", "xr_hud_incoming_call_y", "xr_hud_incoming_call_scale",
+    "xr_hud_phone_message", "xr_hud_phone_message_y", "xr_hud_phone_message_scale",
+    "xr_hud_message_reader", "xr_hud_message_reader_y", "xr_hud_message_reader_scale",
+    "xr_hud_messenger", "xr_hud_messenger_y", "xr_hud_messenger_scale",
     "xr_hud_top_left_alerts", "xr_hud_top_left_alerts_y", "xr_hud_top_left_alerts_scale",
     "xr_hud_top_right", "xr_hud_top_right_y", "xr_hud_top_right_scale",
     "xr_hud_bottom_left", "xr_hud_bottom_left_y", "xr_hud_bottom_left_scale",
@@ -58,6 +62,18 @@ static const char* const kHudKeys[kHudFieldCount] = {
     "xr_hud_johnny_hint", "xr_hud_activity_log", "xr_hud_warning",
     "xr_hud_boss_health", "xr_hud_vehicle_scan", "xr_hud_progress_bar", "xr_hud_oxygen_bar",
 };
+static constexpr int kHudFieldCount = static_cast<int>(sizeof(kHudKeys) / sizeof(kHudKeys[0]));
+static constexpr int kHudHolocallX = 6;
+static constexpr int kHudIncomingCallX = 9;
+static constexpr int kHudPhoneMessageX = 12;
+static constexpr int kHudMessageReaderX = 15;
+static constexpr int kHudMessengerX = 18;
+static_assert(
+    (offsetof(LiveControlsUiState, xrHudOxygenBar) - offsetof(LiveControlsUiState, xrHudScale)) /
+            sizeof(float) +
+        1 ==
+    kHudFieldCount,
+    "kHudKeys must match the contiguous LiveControlsUiState xrHud* field block");
 static float g_hudValues[kHudFieldCount];
 static bool g_hudDefaultsInit = false;
 static bool g_hudLoaded = false;
@@ -70,6 +86,23 @@ static void EnsureHudDefaults() {
         bool isScale = n >= 6 && strcmp(kHudKeys[i] + n - 6, "_scale") == 0;
         g_hudValues[i] = isScale ? 1.0f : 0.0f; // scales default 1.0, offsets 0
     }
+    // Phone surfaces live outside the stock named HUD regions. These defaults
+    // are known-safe in headset. The menu's scale convention is 2.00 = 100%.
+    g_hudValues[kHudHolocallX] = 600.0f;
+    g_hudValues[kHudHolocallX + 1] = 600.0f;
+    g_hudValues[kHudHolocallX + 2] = 2.0f;
+    g_hudValues[kHudIncomingCallX] = 600.0f;
+    g_hudValues[kHudIncomingCallX + 1] = 1050.0f;
+    g_hudValues[kHudIncomingCallX + 2] = 2.0f;
+    g_hudValues[kHudPhoneMessageX] = 600.0f;
+    g_hudValues[kHudPhoneMessageX + 1] = 800.0f;
+    g_hudValues[kHudPhoneMessageX + 2] = 1.8f;
+    g_hudValues[kHudMessageReaderX] = 600.0f;
+    g_hudValues[kHudMessageReaderX + 1] = 500.0f;
+    g_hudValues[kHudMessageReaderX + 2] = 1.4f;
+    g_hudValues[kHudMessengerX] = 1150.0f;
+    g_hudValues[kHudMessengerX + 1] = 500.0f;
+    g_hudValues[kHudMessengerX + 2] = 1.5f;
 }
 static uintptr_t g_gameModuleBase = 0;
 static size_t g_gameModuleSize = 0;
@@ -7321,5 +7354,3 @@ static void InitStereoOnce() {
 __declspec(dllexport) void CyberpunkVRPort_InitStereo() { InitStereoOnce(); }
 
 }
-
-

--- a/src/vr/overlay/imgui_overlay.cpp
+++ b/src/vr/overlay/imgui_overlay.cpp
@@ -912,7 +912,13 @@ bool DrawFovControl(LiveControlsUiState& state) {
 
 // One compact row: <label>  [X][Y][Size]. The label sits in a fixed-width
 // column so the three sliders line up across rows.
-bool DrawHudXYAndScale(const char* label, float* x, float* y, float* scale) {
+bool DrawHudXYAndScale(
+    const char* label,
+    float* x,
+    float* y,
+    float* scale,
+    float xMin = -1200.0f,
+    float xMax = 1200.0f) {
     bool changed = false;
     const float kLabelCol = 150.0f;
     ImGui::PushID(label);
@@ -924,7 +930,7 @@ bool DrawHudXYAndScale(const char* label, float* x, float* y, float* scale) {
     float w = (avail - 2.0f * spacing) / 3.0f;
     if (w < 50.0f) w = 50.0f;
     ImGui::SetNextItemWidth(w);
-    changed |= ImGui::SliderFloat("##x", x, -1200.0f, 1200.0f, "X %.0f");
+    changed |= ImGui::SliderFloat("##x", x, xMin, xMax, "X %.0f");
     ImGui::SameLine();
     ImGui::SetNextItemWidth(w);
     changed |= ImGui::SliderFloat("##y", y, -1200.0f, 1200.0f, "Y %.0f");
@@ -952,6 +958,11 @@ bool DrawHudControls(LiveControlsUiState& state) {
     ImGui::TextUnformatted("Per-region HUD controls: X right+, Y down+, Size 1.00 = half old size, 2.00 = full old size.");
     changed |= DrawHudXYAndScale("Minimap / Quest", &state.xrHudScale, &state.xrHudScaleY, &state.xrHudMinimapQuestScale);
     changed |= DrawHudXYAndScale("HP Bar", &state.xrHudPhone, &state.xrHudPhoneY, &state.xrHudPhoneScale);
+    changed |= DrawHudXYAndScale("Holocall panel", &state.xrHudHolocall, &state.xrHudHolocallY, &state.xrHudHolocallScale);
+    changed |= DrawHudXYAndScale("Call accept prompt", &state.xrHudIncomingCall, &state.xrHudIncomingCallY, &state.xrHudIncomingCallScale);
+    changed |= DrawHudXYAndScale("Incoming text", &state.xrHudPhoneMessage, &state.xrHudPhoneMessageY, &state.xrHudPhoneMessageScale);
+    changed |= DrawHudXYAndScale("Message reader", &state.xrHudMessageReader, &state.xrHudMessageReaderY, &state.xrHudMessageReaderScale);
+    changed |= DrawHudXYAndScale("Messenger browser", &state.xrHudMessenger, &state.xrHudMessengerY, &state.xrHudMessengerScale, -2400.0f, 2400.0f);
     changed |= DrawHudXYAndScale("Top-left alerts", &state.xrHudTopLeftAlerts, &state.xrHudTopLeftAlertsY, &state.xrHudTopLeftAlertsScale);
     changed |= DrawHudXYAndScale("Top-right", &state.xrHudTopRight, &state.xrHudTopRightY, &state.xrHudTopRightScale);
     changed |= DrawHudXYAndScale("Bottom-left main", &state.xrHudBottomLeft, &state.xrHudBottomLeftY, &state.xrHudBottomLeftScale);

--- a/src/vr/overlay/live_controls_ui.h
+++ b/src/vr/overlay/live_controls_ui.h
@@ -35,6 +35,26 @@ struct LiveControlsUiState {
     float xrHudPhoneY;
     float xrHudPhoneScale;
 
+    float xrHudHolocall;
+    float xrHudHolocallY;
+    float xrHudHolocallScale;
+
+    float xrHudIncomingCall;
+    float xrHudIncomingCallY;
+    float xrHudIncomingCallScale;
+
+    float xrHudPhoneMessage;
+    float xrHudPhoneMessageY;
+    float xrHudPhoneMessageScale;
+
+    float xrHudMessageReader;
+    float xrHudMessageReaderY;
+    float xrHudMessageReaderScale;
+
+    float xrHudMessenger;
+    float xrHudMessengerY;
+    float xrHudMessengerScale;
+
     float xrHudTopLeftAlerts;
     float xrHudTopLeftAlertsY;
     float xrHudTopLeftAlertsScale;


### PR DESCRIPTION
## Summary

Adds independent F10 position and size controls for five phone-related VR HUD surfaces:

- Holocall panel
- Call accept prompt
- Incoming text notification
- Expanded message reader
- Messenger contacts/conversation browser

## Implementation

The change extends the existing HUD layout state, persistence keys, and F10 controls. Holocall, call prompt, incoming text, and message-reader widgets are attached to dedicated top-level VR HUD slots. The complete Messenger screen is transformed through `PhoneDialerLogicController.GetRootWidget()`, which keeps the contacts list, conversation view, and controls together without reparenting the fullscreen controller.

Each surface has independent X, Y, and Size values. Defaults were tuned for a narrow VR binocular view, including a centered Messenger default of `1150 / 500 / 1.50` (native scale `0.75`).

## Validation

Built successfully with MSVC and tested in-headset on Cyberpunk 2077 build `3.0.5294808` with the `0.1.1` port baseline.

- All five surfaces rendered in usable VR positions.
- Messenger remained centered and interactive across contacts, conversations, scrolling, and Close.
- F10 adjustment updated the active Messages surface live and displayed its placement preview.
- Saved Messages placement persisted correctly.
- CET and redscript loaded without relevant errors.

This PR contains source changes only; local diagnostic wrappers, test installers, build outputs, and evidence archives are intentionally excluded.
