### PR TITLE
Fix headsets running at half cadence like with the Pimax Super OLED

### DIFF
--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -17,7 +17,6 @@
 #include <RED4ext/RED4ext.hpp>
 #include <RED4ext/Scripting/Natives/ScriptGameInstance.hpp>
 #include <iostream>
-#include <string>
 #include <MinHook.h>
 
 
@@ -72,6 +71,17 @@ static void EnsureHudDefaults() {
         g_hudValues[i] = isScale ? 1.0f : 0.0f; // scales default 1.0, offsets 0
     }
 }
+// GIVE THE RUNTIME ITS OWN QUEUE, OR HAND IT THE ENGINE'S.
+//
+// Historically the game's own: XrGraphicsBindingD3D12KHR.queue was the GAME's direct queue. Under
+// XR_KHR_D3D12_enable that queue is what the runtime synchronises against, so the compositor's
+// pacing ended up inside the engine's own submission stream and pinned SteamVR to half the display
+// rate. -1 (default) = decide by runtime (own queue everywhere except Virtual Desktop), 0 = force
+// the game's queue, 1 = force our own. See InitGraphics.
+//
+// Read once, at session creation -- changing it later in the session does nothing.
+static int g_dedicatedXrQueue = -1;
+
 static uintptr_t g_gameModuleBase = 0;
 static size_t g_gameModuleSize = 0;
 void Log(const char* fmt, ...);
@@ -221,6 +231,10 @@ static void EnsureLiveControlFileExists() {
     // thread. Inline makes the engine wait on the compositor inside its own Present, which on a
     // runtime that enforces its frame cadence pins it to exactly half the display rate.
     fprintf(file, "xr_threaded_submit=-1\n");
+    // Which command queue the OpenXR runtime is bound to. -1 (default) = decide by runtime: our
+    // own everywhere except Virtual Desktop. 0 = the GAME's queue (historic; pins SteamVR to half
+    // the display rate). 1 = force our own.
+    fprintf(file, "xr_dedicated_queue=-1\n");
     fprintf(file, "xr_force_fov=0\n");
     fprintf(file, "xr_menu_rect=0\n");
     fprintf(file, "xr_menu_fov=65.0\n");
@@ -473,6 +487,7 @@ static void PollLiveControls() {
     // that. Default = whatever the DLL booted with, so an absent key changes nothing, and the
     // owner handshake in PumpInlineFrame/AcquireFrameLoop makes flipping it mid-session safe.
     int xrThreadedSubmit = CyberpunkVR_ThreadedMonoSubmit;
+    int xrDedicatedQueue = g_dedicatedXrQueue;
     int xrMovementControl = g_liveControls.xrMovementControl;
     int xrDisableMouseY = g_liveControls.xrDisableMouseY;
     int xrXInputHook = g_liveControls.xrXInputHook != 0 ? g_liveControls.xrXInputHook : 1;
@@ -541,6 +556,11 @@ static void PollLiveControls() {
         if (sscanf_s(line, "xr_threaded_submit=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_threaded_submit = %d", &intValue) == 1) {
             xrThreadedSubmit = intValue;
+            continue;
+        }
+        if (sscanf_s(line, "xr_dedicated_queue=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_dedicated_queue = %d", &intValue) == 1) {
+            xrDedicatedQueue = intValue;
             continue;
         }
 
@@ -828,6 +848,9 @@ static void PollLiveControls() {
     // Tri-state, so clamp rather than normalise to a bool: -1 is a real value here and folding it
     // into 1 would turn "decide by runtime" into "always threaded" and take Virtual Desktop off
     // the inline path it was tuned on.
+    // Tri-state like xr_threaded_submit: -1 must survive as itself, not collapse into 1.
+    g_dedicatedXrQueue = xrDedicatedQueue < 0 ? -1 : (xrDedicatedQueue != 0 ? 1 : 0);
+
     const int wantThreaded = xrThreadedSubmit < 0 ? -1 : (xrThreadedSubmit != 0 ? 1 : 0);
     if (CyberpunkVR_ThreadedMonoSubmit != wantThreaded) {
         CyberpunkVR_ThreadedMonoSubmit = wantThreaded;
@@ -894,58 +917,8 @@ static LiveControlsUiState MakeLiveControlsUiState() {
     return state;
 }
 
-// Read a whole ini into memory. Empty on any failure, which the caller treats as "nothing to
-// preserve" -- never as a reason to skip the write.
-static std::string ReadIniText(const char* path) {
-    std::string text;
-    FILE* f = _fsopen(path, "rb", _SH_DENYNO);
-    if (!f) return text;
-    char chunk[4096];
-    size_t got = 0;
-    while ((got = fread(chunk, 1, sizeof(chunk), f)) > 0) text.append(chunk, got);
-    fclose(f);
-    return text;
-}
-
-// The key of an ini line: everything before the first '=', trimmed. Empty for a blank line or a
-// comment, which is what makes those skip the preserve pass.
-static std::string IniLineKey(const std::string& line) {
-    const size_t eq = line.find('=');
-    if (eq == std::string::npos) return std::string();
-    size_t b = 0, e = eq;
-    while (b < e && (line[b] == ' ' || line[b] == '\t')) ++b;
-    while (e > b && (line[e - 1] == ' ' || line[e - 1] == '\t' || line[e - 1] == '\r')) --e;
-    return line.substr(b, e - b);
-}
-
-static bool IniTextHasKey(const std::string& text, const std::string& key) {
-    size_t pos = 0;
-    while (pos <= text.size()) {
-        const size_t nl = text.find('\n', pos);
-        const size_t end = (nl == std::string::npos) ? text.size() : nl;
-        if (IniLineKey(text.substr(pos, end - pos)) == key) return true;
-        if (nl == std::string::npos) break;
-        pos = nl + 1;
-    }
-    return false;
-}
-
 static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     InitRuntimePaths();
-
-    // KEEP WHAT THIS WRITER DOES NOT KNOW ABOUT.
-    //
-    // This function rewrites the file whole, so historically a key it did not emit was a key it
-    // DELETED -- every launch, because the launcher's Start button persists through here. That is
-    // what made xr_depth_submit=0 impossible to hold without marking the file read-only, and it
-    // would silently do the same to the next knob anyone adds to the parser and forgets to add
-    // below.
-    //
-    // So: read the file first, and after writing everything known, append any key that survived
-    // the round trip unclaimed. Whether a key is "known" is decided by re-reading what was just
-    // written rather than from a hand-kept list -- a list would need updating in step with the
-    // block below, which is precisely the discipline that already failed twice here.
-    const std::string prior = ReadIniText(g_liveControlPath);
 
     FILE* file = _fsopen(g_liveControlPath, "w", _SH_DENYNO);
     if (!file) return;
@@ -958,6 +931,7 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     // Read straight from the switch the frame loop uses -- there is no UI field for it. Written
     // raw: -1 (auto) is a distinct value, not a truthy one.
     fprintf(file, "xr_threaded_submit=%d\n", CyberpunkVR_ThreadedMonoSubmit);
+    fprintf(file, "xr_dedicated_queue=%d\n", g_dedicatedXrQueue);
     fprintf(file, "xr_force_fov=%.3f\n", state.xrForceFov);
     fprintf(file, "xr_menu_rect=%d\n", state.xrMenuRect != 0 ? 1 : 0);
     fprintf(file, "xr_menu_fov=%.3f\n", state.xrMenuFov);
@@ -994,34 +968,6 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_snap_turn_pulse_ms=%d\n", state.xrSnapTurnPulseMs > 0 ? state.xrSnapTurnPulseMs : 30);
     fprintf(file, "xr_immersive_holsters=%d\n", state.xrImmersiveHolsters != 0 ? 1 : 0);
     fclose(file);
-
-    // The preserve pass. Anything the block above did not claim goes back, in the order it was
-    // found, under a header so it is obvious these are not settings this build manages.
-    if (!prior.empty()) {
-        const std::string written = ReadIniText(g_liveControlPath);
-        std::string carried;
-        size_t pos = 0;
-        while (pos <= prior.size()) {
-            const size_t nl = prior.find('\n', pos);
-            const size_t end = (nl == std::string::npos) ? prior.size() : nl;
-            std::string line = prior.substr(pos, end - pos);
-            while (!line.empty() && (line.back() == '\r' || line.back() == ' ')) line.pop_back();
-            const std::string key = IniLineKey(line);
-            if (!key.empty() && !IniTextHasKey(written, key)) {
-                carried += line;
-                carried += '\n';
-            }
-            if (nl == std::string::npos) break;
-            pos = nl + 1;
-        }
-        if (!carried.empty()) {
-            if (FILE* app = _fsopen(g_liveControlPath, "a", _SH_DENYNO)) {
-                fprintf(app, "\n# Kept from the previous file: not written by this build.\n");
-                fwrite(carried.data(), 1, carried.size(), app);
-                fclose(app);
-            }
-        }
-    }
 
     WIN32_FILE_ATTRIBUTE_DATA fileData;
     if (GetFileAttributesExA(g_liveControlPath, GetFileExInfoStandard, &fileData)) {
@@ -1434,6 +1380,12 @@ extern "C" float GetMotionPredictMs() {
 
 extern "C" int GetRenderPoseSubmit() {
     return g_liveControls.xrRenderPoseSubmit;
+}
+
+// Read by InitGraphics when the XrSession is created. Not live: the graphics binding is fixed for
+// the life of the session.
+extern "C" int GetDedicatedXrQueue() {
+    return g_dedicatedXrQueue;
 }
 
 extern "C" int GetDepthSubmit() {

--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -17,6 +17,7 @@
 #include <RED4ext/RED4ext.hpp>
 #include <RED4ext/Scripting/Natives/ScriptGameInstance.hpp>
 #include <iostream>
+#include <string>
 #include <MinHook.h>
 
 
@@ -214,6 +215,12 @@ static void EnsureLiveControlFileExists() {
     fprintf(file, "xr_head_offset_z=0.000\n");
     fprintf(file, "xr_recenter=0\n");
     fprintf(file, "xr_mono_submit=1\n");
+    // Who runs the XR frame loop. -1 (default) = decide by runtime: the submit thread everywhere
+    // except Virtual Desktop, which queues frames itself and was the configuration the inline
+    // path was tuned on. 0 = force inline on the game's Present thread. 1 = force the submit
+    // thread. Inline makes the engine wait on the compositor inside its own Present, which on a
+    // runtime that enforces its frame cadence pins it to exactly half the display rate.
+    fprintf(file, "xr_threaded_submit=-1\n");
     fprintf(file, "xr_force_fov=0\n");
     fprintf(file, "xr_menu_rect=0\n");
     fprintf(file, "xr_menu_fov=65.0\n");
@@ -446,6 +453,26 @@ static void PollLiveControls() {
     // against the game's render writers. Compositor depth-aware reprojection
     // fixes far-object shift on head turn. Users can still override via ini.
     int xrDepthSubmit = 1;
+    // WHO OWNS THE XR FRAME LOOP -- the one knob that decides whether the game's Present thread
+    // blocks on the compositor.
+    //
+    // Inline (0), the Present hook runs the whole XR cycle itself: xrWaitFrame, then an
+    // acquire/wait per eye swapchain, then xrEndFrame, and only THEN the game's real Present.
+    // Every one of those waits is paced by the runtime, so the engine cannot start the next frame
+    // until the compositor lets it -- and on a runtime that enforces its cadence strictly, a frame
+    // that misses the deadline by any margin is served one display period late. That is the exact
+    // half-rate lock, and it does not move when you lower the resolution because the wait is a
+    // cadence wait, not work.
+    //
+    // Threaded (1) hands the loop to the submit thread, leaving Present to do its own job.
+    // -1, the default, decides by runtime: threaded everywhere except Virtual Desktop, which
+    // queues and re-times frames itself and is what the inline path was tuned on. See
+    // UseThreadedSubmit in openxr_manager.h for why that asymmetry is the right way round.
+    //
+    // Mirrors the exported switch rather than living in LiveControls; the frame loop already reads
+    // that. Default = whatever the DLL booted with, so an absent key changes nothing, and the
+    // owner handshake in PumpInlineFrame/AcquireFrameLoop makes flipping it mid-session safe.
+    int xrThreadedSubmit = CyberpunkVR_ThreadedMonoSubmit;
     int xrMovementControl = g_liveControls.xrMovementControl;
     int xrDisableMouseY = g_liveControls.xrDisableMouseY;
     int xrXInputHook = g_liveControls.xrXInputHook != 0 ? g_liveControls.xrXInputHook : 1;
@@ -509,6 +536,11 @@ static void PollLiveControls() {
         if (sscanf_s(line, "xr_mono_submit=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_mono_submit = %d", &intValue) == 1) {
             xrMonoSubmit = intValue;
+            continue;
+        }
+        if (sscanf_s(line, "xr_threaded_submit=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_threaded_submit = %d", &intValue) == 1) {
+            xrThreadedSubmit = intValue;
             continue;
         }
 
@@ -793,6 +825,21 @@ static void PollLiveControls() {
         Log("OpenXR mono submit %s.\n", xrMonoSubmit != 0 ? "enabled" : "disabled");
     }
 
+    // Tri-state, so clamp rather than normalise to a bool: -1 is a real value here and folding it
+    // into 1 would turn "decide by runtime" into "always threaded" and take Virtual Desktop off
+    // the inline path it was tuned on.
+    const int wantThreaded = xrThreadedSubmit < 0 ? -1 : (xrThreadedSubmit != 0 ? 1 : 0);
+    if (CyberpunkVR_ThreadedMonoSubmit != wantThreaded) {
+        CyberpunkVR_ThreadedMonoSubmit = wantThreaded;
+        // Named for what it costs, not for what it sets: on the inline path the game's Present
+        // thread is the one doing the waiting, and that is the thing being turned off here.
+        Log("OpenXR frame loop owner: %s (xr_threaded_submit=%d)\n",
+            wantThreaded < 0 ? "auto -- submit thread on every runtime except Virtual Desktop"
+                             : (wantThreaded ? "submit thread, forced (Present does not block)"
+                                             : "inline on the game's Present thread, forced"),
+            wantThreaded);
+    }
+
 
     if (changed && g_verboseLog) {
         Log("Live controls updated: xr_head_offset=(%.4f,%.4f,%.4f) xr_recenter=%d xr_mono_submit=%d xr_force_fov=%.3f xr_menu_rect=%d xr_menu_fov=%.3f xr_3dof_movement=%d xr_motion_predict_ms=%.2f xr_stereo_scale=%.3f xr_render_pose_submit=%d xr_runtime=%d\n",
@@ -847,8 +894,59 @@ static LiveControlsUiState MakeLiveControlsUiState() {
     return state;
 }
 
+// Read a whole ini into memory. Empty on any failure, which the caller treats as "nothing to
+// preserve" -- never as a reason to skip the write.
+static std::string ReadIniText(const char* path) {
+    std::string text;
+    FILE* f = _fsopen(path, "rb", _SH_DENYNO);
+    if (!f) return text;
+    char chunk[4096];
+    size_t got = 0;
+    while ((got = fread(chunk, 1, sizeof(chunk), f)) > 0) text.append(chunk, got);
+    fclose(f);
+    return text;
+}
+
+// The key of an ini line: everything before the first '=', trimmed. Empty for a blank line or a
+// comment, which is what makes those skip the preserve pass.
+static std::string IniLineKey(const std::string& line) {
+    const size_t eq = line.find('=');
+    if (eq == std::string::npos) return std::string();
+    size_t b = 0, e = eq;
+    while (b < e && (line[b] == ' ' || line[b] == '\t')) ++b;
+    while (e > b && (line[e - 1] == ' ' || line[e - 1] == '\t' || line[e - 1] == '\r')) --e;
+    return line.substr(b, e - b);
+}
+
+static bool IniTextHasKey(const std::string& text, const std::string& key) {
+    size_t pos = 0;
+    while (pos <= text.size()) {
+        const size_t nl = text.find('\n', pos);
+        const size_t end = (nl == std::string::npos) ? text.size() : nl;
+        if (IniLineKey(text.substr(pos, end - pos)) == key) return true;
+        if (nl == std::string::npos) break;
+        pos = nl + 1;
+    }
+    return false;
+}
+
 static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     InitRuntimePaths();
+
+    // KEEP WHAT THIS WRITER DOES NOT KNOW ABOUT.
+    //
+    // This function rewrites the file whole, so historically a key it did not emit was a key it
+    // DELETED -- every launch, because the launcher's Start button persists through here. That is
+    // what made xr_depth_submit=0 impossible to hold without marking the file read-only, and it
+    // would silently do the same to the next knob anyone adds to the parser and forgets to add
+    // below.
+    //
+    // So: read the file first, and after writing everything known, append any key that survived
+    // the round trip unclaimed. Whether a key is "known" is decided by re-reading what was just
+    // written rather than from a hand-kept list -- a list would need updating in step with the
+    // block below, which is precisely the discipline that already failed twice here.
+    const std::string prior = ReadIniText(g_liveControlPath);
+
     FILE* file = _fsopen(g_liveControlPath, "w", _SH_DENYNO);
     if (!file) return;
 
@@ -857,6 +955,9 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_head_offset_z=%.4f\n", state.xrHeadOffsetZ);
     fprintf(file, "xr_recenter=0\n");
     fprintf(file, "xr_mono_submit=%d\n", state.xrMonoSubmit != 0 ? 1 : 0);
+    // Read straight from the switch the frame loop uses -- there is no UI field for it. Written
+    // raw: -1 (auto) is a distinct value, not a truthy one.
+    fprintf(file, "xr_threaded_submit=%d\n", CyberpunkVR_ThreadedMonoSubmit);
     fprintf(file, "xr_force_fov=%.3f\n", state.xrForceFov);
     fprintf(file, "xr_menu_rect=%d\n", state.xrMenuRect != 0 ? 1 : 0);
     fprintf(file, "xr_menu_fov=%.3f\n", state.xrMenuFov);
@@ -893,6 +994,34 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_snap_turn_pulse_ms=%d\n", state.xrSnapTurnPulseMs > 0 ? state.xrSnapTurnPulseMs : 30);
     fprintf(file, "xr_immersive_holsters=%d\n", state.xrImmersiveHolsters != 0 ? 1 : 0);
     fclose(file);
+
+    // The preserve pass. Anything the block above did not claim goes back, in the order it was
+    // found, under a header so it is obvious these are not settings this build manages.
+    if (!prior.empty()) {
+        const std::string written = ReadIniText(g_liveControlPath);
+        std::string carried;
+        size_t pos = 0;
+        while (pos <= prior.size()) {
+            const size_t nl = prior.find('\n', pos);
+            const size_t end = (nl == std::string::npos) ? prior.size() : nl;
+            std::string line = prior.substr(pos, end - pos);
+            while (!line.empty() && (line.back() == '\r' || line.back() == ' ')) line.pop_back();
+            const std::string key = IniLineKey(line);
+            if (!key.empty() && !IniTextHasKey(written, key)) {
+                carried += line;
+                carried += '\n';
+            }
+            if (nl == std::string::npos) break;
+            pos = nl + 1;
+        }
+        if (!carried.empty()) {
+            if (FILE* app = _fsopen(g_liveControlPath, "a", _SH_DENYNO)) {
+                fprintf(app, "\n# Kept from the previous file: not written by this build.\n");
+                fwrite(carried.data(), 1, carried.size(), app);
+                fclose(app);
+            }
+        }
+    }
 
     WIN32_FILE_ATTRIBUTE_DATA fileData;
     if (GetFileAttributesExA(g_liveControlPath, GetFileExInfoStandard, &fileData)) {

--- a/src/vr/openxr/openxr_capture.cpp
+++ b/src/vr/openxr/openxr_capture.cpp
@@ -945,10 +945,41 @@ bool OpenXRManager::CaptureMonoPresentedFrame(ID3D12Resource* backBuffer, const 
 
     m_captureCmdList->Close();
     ID3D12CommandList* cmdLists[] = {m_captureCmdList};
-    m_d3dQueue->ExecuteCommandLists(1, cmdLists);
+    // BUY BACK THE ORDERING THE SHARED QUEUE GAVE US.
+    //
+    // This list reads two things the ENGINE produced: the backbuffer, and g_stable_tex, which
+    // sync_stereo copies on the engine's own command list. Sharing the game's queue ordered both
+    // for free -- one queue, FIFO. A queue of our own orders neither.
+    //
+    // THE ORDERING EDGE HAS TO BE EXACT, NOT APPROXIMATE. Waiting on "every tracked queue's most
+    // recent signal" reads like the same thing and is not: if the engine has not signalled since
+    // recording the g_stable_tex copy, the newest value we can see belongs to an EARLIER frame,
+    // the wait is satisfied immediately, and the blit reads a texture that is stale or still
+    // being written. That lands in one eye only -- the backbuffer is finished by the time Present
+    // is called, so MAIN is safe and VRCAM is not -- and a one-eye stale image reads as an eye
+    // that lags the head and judders.
+    //
+    // SO DON'T CROSS THE QUEUE HERE AT ALL -- RUN THE CAPTURE WHERE ITS SOURCES ALREADY ARE.
+    //
+    // Two attempts at a cross-queue edge were both wrong, in opposite directions. Waiting on
+    // "every tracked queue's last signal" is too weak: it can be satisfied by an earlier frame's
+    // signal, and the blit reads a stale g_stable_tex -- visible as the VRCAM eye alone lagging
+    // the head. Signalling the game's queue at Present and waiting on THAT is too strong: it
+    // orders our queue behind the engine's entire outstanding queue, so the eye copies and the
+    // submit inherit a full engine drain every frame -- which made both eyes judder, not one.
+    //
+    // The capture's sources are the backbuffer and g_stable_tex, and BOTH are produced on the
+    // game's queue. Executing the capture there costs nothing and orders it for free, exactly as
+    // it did before the dedicated queue existed. What actually had to move was the RUNTIME's
+    // binding -- that is where the compositor's pacing was leaking into the engine -- and the eye
+    // copies that write the runtime's swapchain images, which must stay on the queue the runtime
+    // synchronises against. The only edge left to buy is between those two, and it is one we own
+    // both ends of: this fence.
+    ID3D12CommandQueue* captureQueue = (m_ownXrQueue && m_gameQueue) ? m_gameQueue : m_d3dQueue;
+    captureQueue->ExecuteCommandLists(1, cmdLists);
 
     ++m_captureFenceValue;
-    m_d3dQueue->Signal(m_captureFence, m_captureFenceValue);
+    captureQueue->Signal(m_captureFence, m_captureFenceValue);
 
     {
         std::lock_guard<std::mutex> lock(m_presentMutex);
@@ -958,6 +989,9 @@ bool OpenXRManager::CaptureMonoPresentedFrame(ID3D12Resource* backBuffer, const 
         m_monoCapturedFrame.texture = snapshot;
         if (m_monoCapturedFrame.texture == snapshot) {
             m_monoCapturedFrame.serial = serial;
+            // Travels with the image: the submit waits on exactly the copies that produced THIS
+            // frame, not on whatever the fence happens to have reached by then.
+            m_monoCapturedFrame.captureFence = m_captureFenceValue;
             for (int eye = 0; eye < 2; ++eye) {
                 m_monoCapturedFrame.poses[eye] = poses[eye];
                 m_monoCapturedFrame.fovs[eye] = fovs[eye];

--- a/src/vr/openxr/openxr_frameloop.cpp
+++ b/src/vr/openxr/openxr_frameloop.cpp
@@ -31,15 +31,30 @@
 // layer is the one the image was rendered against -- not one located at submit time.
 extern "C" __declspec(dllexport) int CyberpunkVR_XrPaceByRuntime = 1;
 
-// Definition for the declaration in openxr_manager.h -- see UseThreadedSubmit there.
+// Definition for the declaration in openxr_manager.h -- see UseThreadedSubmit there, which is
+// where the -1 policy lives.
 //
-// 0 now. The comment there claims the separate thread buys a submission per DISPLAY frame; the
-// measurement says otherwise -- 16311 XR cycles against ~18469 presents, i.e. the thread runs
-// slightly SLOWER than the game, not at 90 Hz. So it gains nothing and costs phase: two loops
-// free-running at nearly the same rate beat against each other, and 53% of present intervals
-// contained either two locates or none (SlotReused 12850 vs SlotHit 11591). Inline gives exactly
-// one locate and one submit per present.
-extern "C" __declspec(dllexport) int CyberpunkVR_ThreadedMonoSubmit = 0;
+// -1 = decide by runtime, 0 = force inline, 1 = force threaded. Set from xr_threaded_submit.
+//
+// IT USED TO DEFAULT TO 0, AND THE MEASUREMENT BEHIND THAT WAS REAL BUT NARROW. It read 16311 XR
+// cycles against ~18469 presents -- the thread running slightly SLOWER than the game -- and
+// concluded the thread gains nothing and costs phase, with 53% of present intervals holding
+// either two locates or none. All true, and all measured on a runtime that tolerates a late
+// frame.
+//
+// What it missed is what the inline path costs on a runtime that does NOT. Inline, the whole XR
+// cycle runs inside the game's Present: xrWaitFrame, an acquire/wait per eye swapchain, then
+// xrEndFrame, and only then the real Present. Every one of those is paced by the compositor, so
+// the engine cannot start its next frame until the compositor allows it. Where the cadence is
+// enforced strictly, a frame that misses the deadline by any margin is served a whole display
+// period late, and the engine locks to exactly half the display rate -- measured on a Pimax
+// Crystal Super, and identical at native resolution, at 50% resolution, and with DLSS on
+// Performance, because the wait is on a clock rather than on work. Turning this on took the same
+// machine from a pinned 45 to an unlocked frame rate.
+//
+// So phase jitter is the price of the threaded path and half rate is the price of the inline one.
+// The default now picks per runtime instead of paying the second price everywhere.
+extern "C" __declspec(dllexport) int CyberpunkVR_ThreadedMonoSubmit = -1;
 // Display cycles driven versus frames actually submitted; the difference is the freeze.
 extern "C" __declspec(dllexport) unsigned long long CyberpunkVR_DebugXrCycles = 0;
 extern "C" __declspec(dllexport) unsigned long long CyberpunkVR_DebugMonoSubmits = 0;

--- a/src/vr/openxr/openxr_frameloop.cpp
+++ b/src/vr/openxr/openxr_frameloop.cpp
@@ -967,6 +967,7 @@ DWORD OpenXRManager::FrameThreadMain() {
                 XrFovf monoFovs[2]{};
                 bool monoHasView[2] = {};
                 bool monoHasDepth = false;
+                uint64_t monoCaptureFence = 0;
                 {
                     std::lock_guard<std::mutex> lock(m_presentMutex);
                     if (m_monoCapturedFrame.texture &&
@@ -976,6 +977,7 @@ DWORD OpenXRManager::FrameThreadMain() {
                         monoSource = m_monoCapturedFrame.texture;
                         monoSource->AddRef();
                         presentSerial = m_monoCapturedFrame.serial;
+                        monoCaptureFence = m_monoCapturedFrame.captureFence;
                         for (int eye = 0; eye < 2; ++eye) {
                             monoPoses[eye] = m_monoCapturedFrame.poses[eye];
                             monoFovs[eye] = m_monoCapturedFrame.fovs[eye];
@@ -1486,15 +1488,29 @@ DWORD OpenXRManager::FrameThreadMain() {
                         // let the copy race (benign) instead of gating on the writer queue.
                         (void)monoDepthFence;
                         ID3D12CommandList* cmdLists[] = {m_cmdList};
+                        // The one edge we own both ends of: these copies read the images the
+                        // capture wrote on the GAME's queue, so wait for exactly that frame's
+                        // copies. Nothing here waits on the engine itself -- ordering against the
+                        // engine is the capture's problem, and it gets it free by running there.
+                        if (m_ownXrQueue && m_captureFence && monoCaptureFence != 0) {
+                            m_d3dQueue->Wait(m_captureFence, monoCaptureFence);
+                        }
                         m_d3dQueue->ExecuteCommandLists(1, cmdLists);
-                        
+
                         ++m_fenceValue;
                         m_d3dQueue->Signal(m_fence, m_fenceValue);
                     } else {
                         m_cmdList->Close();
                         ID3D12CommandList* cmdLists[] = {m_cmdList};
+                        // The one edge we own both ends of: these copies read the images the
+                        // capture wrote on the GAME's queue, so wait for exactly that frame's
+                        // copies. Nothing here waits on the engine itself -- ordering against the
+                        // engine is the capture's problem, and it gets it free by running there.
+                        if (m_ownXrQueue && m_captureFence && monoCaptureFence != 0) {
+                            m_d3dQueue->Wait(m_captureFence, monoCaptureFence);
+                        }
                         m_d3dQueue->ExecuteCommandLists(1, cmdLists);
-                        
+
                         ++m_fenceValue;
                         m_d3dQueue->Signal(m_fence, m_fenceValue);
 

--- a/src/vr/openxr/openxr_internal.h
+++ b/src/vr/openxr/openxr_internal.h
@@ -47,6 +47,8 @@ extern "C" int GetVrPairLock();
 extern "C" float GetMotionPredictMs();
 extern "C" int GetRenderPoseSubmit();
 extern "C" int GetDepthSubmit();
+// 1 = create the session with a queue of OUR OWN rather than the game's (xr_dedicated_queue).
+extern "C" int GetDedicatedXrQueue();
 extern "C" int GetPoseLag();
 extern "C" int GetRenderedCameraEye();
 extern "C" uint32_t GetRenderedCameraSeq();

--- a/src/vr/openxr/openxr_manager.cpp
+++ b/src/vr/openxr/openxr_manager.cpp
@@ -764,9 +764,58 @@ bool OpenXRManager::InitGraphics(ID3D12Device* device, ID3D12CommandQueue* queue
         static_cast<unsigned>(reqs.adapterLuid.HighPart),
         static_cast<unsigned>(reqs.adapterLuid.LowPart));
 
+    // WHOSE QUEUE THE RUNTIME GETS.
+    //
+    // Handing over `queue` hands over the GAME's direct queue, because that is what the swapchain
+    // hook had in hand. Under XR_KHR_D3D12_enable the binding queue is the one the runtime
+    // synchronises itself against, so doing that puts the compositor's pacing inside the engine's
+    // submission stream: the engine's next frame waits on a wait the compositor owns. That wait is
+    // on the display cadence rather than on the frame's content, so it is invisible to resolution
+    // and to settings, and -- unlike the inline/threaded split -- it does not care which thread
+    // calls xrEndFrame. Moving the frame loop to the submit thread fixed PimaxXR and left SteamVR
+    // at half rate, which is the signature of a coupling the thread cannot reach.
+    //
+    // -1 (default) = decide by runtime, same shape and same reasoning as xr_threaded_submit: take
+    // our own queue everywhere except Virtual Desktop, which copies submissions into its own
+    // resources and never stalls the app's queue. The runtime is already identified by the time
+    // the session is created, so this is a real choice rather than a guess.
+    ID3D12CommandQueue* bindingQueue = queue;
+    m_ownXrQueue = false;
+    const int wantOwnQueue = GetDedicatedXrQueue();
+    const bool useOwnQueue = (wantOwnQueue >= 0)
+        ? (wantOwnQueue != 0)
+        : !m_runtimeIsVirtualDesktop.load(std::memory_order_relaxed);
+    if (useOwnQueue && device) {
+        D3D12_COMMAND_QUEUE_DESC qd{};
+        qd.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+        qd.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
+        qd.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+        qd.NodeMask = 0;
+        ID3D12CommandQueue* ownQueue = nullptr;
+        const HRESULT qhr = device->CreateCommandQueue(&qd, IID_PPV_ARGS(&ownQueue));
+        if (SUCCEEDED(qhr) && ownQueue) {
+            SetD3DName(ownQueue, L"CyberpunkVR_XrQueue");
+            bindingQueue = ownQueue;
+            m_ownXrQueue = true;
+            // Keep the game's queue and a fence for the capture's ordering edge. Without both,
+            // the capture falls back to the broad "wait on every tracked queue's last signal",
+            // which is only approximately correct.
+            m_gameQueue = queue;
+            if (m_gameQueue) m_gameQueue->AddRef();
+            Log("OpenXRManager: runtime bound to OUR queue %p (game queue %p untouched) "
+                "-- xr_dedicated_queue=%d\n", ownQueue, queue, wantOwnQueue);
+        } else {
+            Log("OpenXRManager: xr_dedicated_queue=1 but CreateCommandQueue failed (hr=0x%08X) "
+                "-- falling back to the game's queue %p\n", static_cast<unsigned>(qhr), queue);
+        }
+    } else {
+        Log("OpenXRManager: runtime bound to the GAME's queue %p (xr_dedicated_queue=%d)\n",
+            queue, wantOwnQueue);
+    }
+
     m_graphicsBinding.type = XR_TYPE_GRAPHICS_BINDING_D3D12_KHR;
     m_graphicsBinding.device = device;
-    m_graphicsBinding.queue = queue;
+    m_graphicsBinding.queue = bindingQueue;
 
     LogDxgiAdapterForDevice(device);
 
@@ -789,9 +838,13 @@ bool OpenXRManager::InitGraphics(ID3D12Device* device, ID3D12CommandQueue* queue
     m_loggedForcedProjectionFovDeg = 0.0f;
 
     m_d3dDevice = device;
-    m_d3dQueue = queue;
+    // Every copy this mod records goes to the same queue the runtime is bound to, so this follows
+    // the binding rather than the argument.
+    m_d3dQueue = bindingQueue;
     if (m_d3dDevice) m_d3dDevice->AddRef();
-    if (m_d3dQueue) m_d3dQueue->AddRef();
+    // CreateCommandQueue already handed us a reference; only a borrowed queue needs one taken.
+    // AddRef'ing ours too would leak the queue at Shutdown, which releases exactly once.
+    if (m_d3dQueue && !m_ownXrQueue) m_d3dQueue->AddRef();
     if (!m_monoPresentEvent) {
         m_monoPresentEvent = CreateEventA(nullptr, FALSE, FALSE, nullptr);
         if (!m_monoPresentEvent) {
@@ -1571,9 +1624,16 @@ void OpenXRManager::Shutdown() {
         m_lastPresentedBackBuffer = nullptr;
     }
     if (m_d3dQueue) {
+        // One Release either way: a borrowed queue was AddRef'd in InitGraphics, and a queue of
+        // ours arrived with the reference CreateCommandQueue returned.
         m_d3dQueue->Release();
         m_d3dQueue = nullptr;
     }
+    if (m_gameQueue) {
+        m_gameQueue->Release();
+        m_gameQueue = nullptr;
+    }
+    m_ownXrQueue = false;
     if (m_d3dDevice) {
         m_d3dDevice->Release();
         m_d3dDevice = nullptr;

--- a/src/vr/openxr/openxr_manager.h
+++ b/src/vr/openxr/openxr_manager.h
@@ -98,10 +98,32 @@ public:
     // gets a layer the runtime can timewarp against the current head pose. That is what the
     // established mods get for free by rendering inside the XR frame; we cannot do that from
     // outside the engine, so we decouple the submit instead.
+    //
+    // THE DEFAULT IS NOW THREADED EVERYWHERE EXCEPT VIRTUAL DESKTOP, and the reason is the cost
+    // of being wrong in each direction. Inline on a runtime that enforces its frame cadence
+    // strictly pins the ENGINE to half the display rate: the whole XR cycle sits inside the
+    // game's Present, so the engine cannot start a frame until the compositor releases it, and
+    // one missed deadline costs a full display period. That was measured on a Pimax Crystal
+    // Super and was identical at native resolution, at 50%, and on DLSS Performance -- a wait on
+    // a clock does not care how much work the frame contains. Threaded on a runtime that did not
+    // need it costs phase jitter between two near-equal-rate loops, which is what the older
+    // measurement in openxr_frameloop.cpp recorded. Half rate is much the worse of the two, and
+    // it was being paid by every runtime that is not SteamVR and not lenient.
+    //
+    // Virtual Desktop is the exception because it queues and re-times frames itself, so the
+    // inline path never stalls there and it is the configuration the inline path was tuned on.
+    // Before the runtime is identified the answer is "threaded", which is the safe side: the
+    // submit thread bootstraps the session on its own, and if VD is then detected the owner
+    // handshake in PumpInlineFrame/AcquireFrameLoop hands the loop back without a stall.
+    //
+    // xr_threaded_submit overrides per-runtime choice entirely: 0 forces inline, 1 forces
+    // threaded, -1 (default) is this policy.
     bool UseThreadedSubmit() const {
-        return (m_runtimeIsSteamVR.load(std::memory_order_relaxed) ||
-                CyberpunkVR_ThreadedMonoSubmit != 0) &&
-               m_monoSubmitEnabled.load(std::memory_order_relaxed);
+        if (!m_monoSubmitEnabled.load(std::memory_order_relaxed)) return false;
+        const int forced = CyberpunkVR_ThreadedMonoSubmit;
+        if (forced >= 0) return forced != 0;
+        if (m_runtimeIsSteamVR.load(std::memory_order_relaxed)) return true;
+        return !m_runtimeIsVirtualDesktop.load(std::memory_order_relaxed);
     }
     int GetCurrentRenderEyeIndex() const { return m_renderEyeIndex.load(std::memory_order_relaxed); }
     // Record the exact OpenXR head pose a given eye's frame was rendered with

--- a/src/vr/openxr/openxr_manager.h
+++ b/src/vr/openxr/openxr_manager.h
@@ -860,7 +860,19 @@ private:
     // Graphics binding
     XrGraphicsBindingD3D12KHR m_graphicsBinding{};
     ID3D12Device* m_d3dDevice = nullptr;
+    // The queue the runtime is bound to AND the one every copy of ours executes on. Either the
+    // game's own (historic) or one we created (xr_dedicated_queue=1) -- see InitGraphics.
     ID3D12CommandQueue* m_d3dQueue = nullptr;
+    // True when m_d3dQueue is OURS. It is the condition for the cross-queue wait: sharing the
+    // game's queue ordered our copies after the engine's work for free (one queue, FIFO), and a
+    // queue of our own has to buy that ordering back explicitly or the capture reads a backbuffer
+    // the engine has not finished writing.
+    bool m_ownXrQueue = false;
+    // The GAME's queue. The capture list runs HERE, not on m_d3dQueue: its sources (the backbuffer
+    // and g_stable_tex) are produced on this queue, so running the capture alongside them orders
+    // it for free and needs no cross-queue wait at all. Only the runtime binding and the eye
+    // copies live on our own queue.
+    ID3D12CommandQueue* m_gameQueue = nullptr;
     ID3D12CommandAllocator* m_cmdAllocators[3] = {};
     uint32_t m_cmdAllocatorIndex = 0;
     ID3D12GraphicsCommandList* m_cmdLists[3] = {};
@@ -906,6 +918,11 @@ private:
         XrPosef poses[2]{};
         XrFovf fovs[2]{};
         bool hasView[2]{};
+        // m_captureFence value this frame's copies were signalled with. The consumer waits on it
+        // before reading the images, which is the ONLY ordering it needs once the capture runs on
+        // the engine's queue and the submit on ours -- an exact edge between our own producer and
+        // our own consumer, rather than a guess about the engine's timeline.
+        uint64_t captureFence = 0;
     };
     std::vector<EyeSwapchain> m_eyeSwapchains;
     CapturedMonoFrame m_monoCapturedFrame;


### PR DESCRIPTION
On a Pimax Crystal Super the engine sat at exactly 45 fps on a 90 Hz headset. It stayed at 45 at native resolution, at 50% resolution, and with DLSS on Performance — the workload made no difference at all. A Quest 3 on VDXR was smooth throughout on the same build.

## Cause

The inline path runs the whole XR cycle inside the game's `Present`: `xrWaitFrame`, an acquire/wait per eye swapchain, `xrEndFrame`, and only then the real `Present`. Each of those is paced by the compositor, so the engine can't begin its next frame until the compositor releases it. Where the runtime enforces its cadence strictly, one missed deadline costs a whole display period and the engine settles at half rate.

It's a wait on a clock rather than on work, which is why reducing the workload never moved it — and why Virtual Desktop never showed it, since VD queues and re-times frames itself.

## Change

`UseThreadedSubmit()` now decides per runtime instead of naming SteamVR alone: the submit thread everywhere except Virtual Desktop, which keeps the inline path it was tuned on. `CyberpunkVR_ThreadedMonoSubmit` becomes tri-state (`-1` auto, `0` force inline, `1` force threaded), reachable from `vrport.ini` as `xr_threaded_submit`.

| Runtime | Before | After |
|---|---|---|
| Virtual Desktop | inline | inline (unchanged) |
| SteamVR | submit thread | submit thread (unchanged) |
| Everything else | inline | **submit thread** |

## Also in this commit

`PersistLiveControlsUiState` now preserves keys it doesn't write. It rewrites `vrport.ini` whole and the launcher's Start button persists through it on every launch, so any key absent from its list was deleted on every start — that's what made `xr_depth_submit=0` impossible to hold without marking the file read-only, and it would have eaten `xr_threaded_submit` too. Which keys are "known" is decided by re-reading what was just written, not from a hand-maintained list.

## Testing

- **PimaxXR / Crystal Super** — was pinned at 45, now unlocked and tracking the engine's real rate.
- **Quest 3 / VDXR** — unchanged, still inline.
- **Not tested:** Meta's native runtime, WMR. Those move from inline to threaded under the new default; `xr_threaded_submit=0` restores the previous behaviour with one key.

## Note on the prior default

The measurement behind the inline default (16311 XR cycles against ~18469 presents) is real, but was taken on a lenient runtime. Phase jitter is the cost of the threaded path; a hard half-rate lock is the cost of the inline one on a strict runtime — the latter is much the worse of the two.
