### PR TITLE
VRIK: fully suspend body IK during cutscenes (tunable)

### DIFF
--- a/mods/cet/CyberpunkVRPort_VRIK/init.lua
+++ b/mods/cet/CyberpunkVRPort_VRIK/init.lua
@@ -483,6 +483,22 @@ registerForEvent('onUpdate', function(dt)
         pcall(function() UpdateVRIKAnimInputs() end)
     end
 
+    -- CUTSCENE SUSPEND: publish the player's live scene tier so the plugin's pose-apply
+    -- hook can fully suspend VRIK during scripted scenes / cinematics (the engine plays an
+    -- authored body+arm animation there and VRIK fighting it looks wrong). SceneTier is a
+    -- GameplayTier int on the per-entity PlayerStateMachine blackboard: 0 = Tier1_FullGameplay,
+    -- 1 = Tier2_StagedGameplay, 2 = Tier3, 3 = Tier4_FPPCinematic, 4 = Tier5_Cinematic. The
+    -- overlay owns the threshold (F10 VRIK tab); here we only report the current tier.
+    if type(SetVRSceneTier) == 'function' then
+        pcall(function()
+            local defs = Game.GetAllBlackboardDefs()
+            local bb = Game.GetBlackboardSystem():GetLocalInstanced(player:GetEntityID(), defs.PlayerStateMachine)
+            if bb then
+                SetVRSceneTier(bb:GetInt(defs.PlayerStateMachine.SceneTier))
+            end
+        end)
+    end
+
     local player = Game.GetPlayer()
     if not player then return end
     

--- a/src/common/shared_slots.h
+++ b/src/common/shared_slots.h
@@ -115,6 +115,11 @@
 //  [154]       left trigger analog (0..1)     plugin -> Smoking CET bridge
 //  [155]       left grip pressed (0/1)        plugin -> Smoking CET bridge
 //  [156]       DEBUG logging on (0/1)         plugin -> every CET bridge
+//  [157]       player scene tier (GameplayTier int: 0=Tier1_FullGameplay ..
+//              3=Tier4_FPPCinematic, 4=Tier5_Cinematic)   VRIK CET -> hook
+//  [158]       cutscene VRIK-suspend threshold, encoded (0 = disabled; else the
+//              hook suspends the WHOLE body+arm solve while [157] >= [158]-1)
+//              stereo/overlay (LiveControls) -> hook
 // ============================================================================
 
 namespace vrshared {
@@ -149,4 +154,10 @@ constexpr int kLeftGripPressed   = 155;
 // smoking one alone in a single session, and as much again from the weapon one. A log nobody can
 // open is a log nobody reads.
 constexpr int kDebugLog          = 156;
+// Cutscene body suspend. [157] is the live player GameplayTier int published by the VRIK CET mod
+// (0 = Tier1_FullGameplay .. 3 = Tier4_FPPCinematic, 4 = Tier5_Cinematic). [158] is the encoded
+// suspend threshold from the overlay: 0 = feature off, otherwise the VRIK hook fully suspends the
+// body+arm solve (leaving the engine's authored cinematic pose) while sceneTier >= [158] - 1.
+constexpr int kSceneTier         = 157;
+constexpr int kCutsceneSuspendEnc = 158;
 } // namespace vrshared

--- a/src/red4ext_plugin/main.cpp
+++ b/src/red4ext_plugin/main.cpp
@@ -7045,6 +7045,15 @@ void SetVRMeleeFire(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, 
     int32_t v = 0; RED4ext::GetParameter(aFrame, &v); aFrame->code++;
     if (g_pSharedHands) g_pSharedHands[29] = (float)v;
 }
+// Player scene tier -> shared[157]. The VRIK CET mod reads PlayerStateMachine.SceneTier
+// (a GameplayTier: 0 = Tier1_FullGameplay .. 3 = Tier4_FPPCinematic, 4 = Tier5_Cinematic) each
+// frame and pushes it here. The pose-apply hook combines it with the overlay's suspend threshold
+// in [158] to fully suspend VRIK during cutscenes (see vrik_hook.h).
+void SetVRSceneTier(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t) {
+    int32_t v = 0; RED4ext::GetParameter(aFrame, &v); aFrame->code++;
+    EnsureSharedMemory();
+    if (g_pSharedHands) g_pSharedHands[157] = (float)v;
+}
 // Live MODE of the Aim_JNT shake kill (g_VRCamBoneFreeze: 0 stock / 1 yaw-live / 2 full /
 // 3 swing-only).
 void SetVRCamBoneFreeze(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t) {
@@ -7571,6 +7580,8 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes() {
     fZoom->flags = flags; fZoom->AddParam("Float","zoom"); rtti->RegisterFunction(fZoom);
     auto fMeleeFire = RED4ext::CGlobalFunction::Create("SetVRMeleeFire", "SetVRMeleeFire", &SetVRMeleeFire);
     fMeleeFire->flags = flags; fMeleeFire->AddParam("Int32","fire"); rtti->RegisterFunction(fMeleeFire);
+    auto fSceneTier = RED4ext::CGlobalFunction::Create("SetVRSceneTier", "SetVRSceneTier", &SetVRSceneTier);
+    fSceneTier->flags = flags; fSceneTier->AddParam("Int32","tier"); rtti->RegisterFunction(fSceneTier);
     auto fCamFreeze = RED4ext::CGlobalFunction::Create("SetVRCamBoneFreeze", "SetVRCamBoneFreeze", &SetVRCamBoneFreeze);
     fCamFreeze->flags = flags; fCamFreeze->AddParam("Int32","on"); rtti->RegisterFunction(fCamFreeze);
     auto fPairSlew = RED4ext::CGlobalFunction::Create("SetVRPairSlew", "SetVRPairSlew", &SetVRPairSlew);

--- a/src/red4ext_plugin/vrik/vrik_hook.h
+++ b/src/red4ext_plugin/vrik/vrik_hook.h
@@ -2140,6 +2140,23 @@ extern "C" inline void* Hooked_AnimPoseApply(void* a1, void* a2, void* a3, unsig
                 // present thread).
                 RefreshHandsSnapshot();
 
+                // CUTSCENE FULL-SUSPEND. During scripted scenes / cinematics the engine plays a
+                // fully authored body+arm animation; letting VRIK keep solving fights it and the
+                // avatar looks wrong. The VRIK CET mod publishes the live GameplayTier into raw
+                // slot [157] and the overlay publishes an encoded threshold into [158] (0 = off;
+                // else suspend while tier >= [158]-1). Read RAW here (NOT SharedPose: the seqlock
+                // snapshot only latches [0..126], so 157/158 are out of that array). We bail before
+                // any bone write, leaving the engine's native cinematic pose untouched -- and after
+                // ++g_AnimPoseMatchCalls above, so the CET desync detector stays healthy and does
+                // not re-arm in a storm during the scene.
+                if (g_pSharedHands) {
+                    const int sceneTier = static_cast<int>(g_pSharedHands[157] + 0.5f);
+                    const int suspendEnc = static_cast<int>(g_pSharedHands[158] + 0.5f);
+                    if (suspendEnc > 0 && sceneTier >= (suspendEnc - 1)) {
+                        return result;
+                    }
+                }
+
                 // SMOKE FINGER-HOLD (fingers-only grip). Runs on EVERY player pass, BEFORE
                 // the solve/replay split, so the curl is bit-identical across the 4-5
                 // passes/tick -> no finger flicker. The original ran at the top of this

--- a/src/vr/core/vr_core.cpp
+++ b/src/vr/core/vr_core.cpp
@@ -117,6 +117,7 @@ struct LiveControls {
     volatile int xrSnapTurnYawIndex; // which float index in deltaHead[] gets the snap yaw. Default 1.
     volatile int xrImmersiveHolsters; // 1 = visual-holster equip (default), 0 = simple slot mapping (back=Slot1, R hip=Slot2, L hip=Slot3). Published to shared[23] for the CET Holster mod.
     volatile int xrPhysicalBodyRotation; // 1 = physical body rotation (avatar body follows HMD/aim heading). 0 (default) = classic stick/snap heading. Gates the aiming/weapon body-turn paths; vehicles unaffected.
+    volatile int xrCutsceneSuspendTier;  // min GameplayTier to fully suspend VRIK during scenes (-1 = never, 0..4 = Tier1..Tier5). Default 3 (Tier4 cinematics). Published (encoded) to shared[158] for the pose-apply hook.
 };
 
 static constexpr int kEnablePatchBufferTracer = 0;
@@ -171,6 +172,10 @@ void InitRuntimePaths() {
 
     // Default: immersive holsters ON (current behaviour -- equip by visual holster).
     g_liveControls.xrImmersiveHolsters = 1;
+
+    // Default: suspend VRIK during true cinematics (Tier4_FPPCinematic and up). The avatar
+    // is driven by the engine's authored scene animation there; VRIK fighting it looks wrong.
+    g_liveControls.xrCutsceneSuspendTier = 3;
 
     // Default ON: VR controller -> XInput gamepad pipeline. Both the entry-point
     // detour (xrXInputInstall) and the gameplay action set (xrInputActions) are
@@ -477,6 +482,7 @@ static void PollLiveControls() {
     int xrSnapTurnYawIndex = g_liveControls.xrSnapTurnYawIndex >= 0 && g_liveControls.xrSnapTurnYawIndex <= 3 ? g_liveControls.xrSnapTurnYawIndex : 1;
     int xrImmersiveHolsters = g_liveControls.xrImmersiveHolsters;
     int xrPhysicalBodyRotation = g_liveControls.xrPhysicalBodyRotation;
+    int xrCutsceneSuspendTier = g_liveControls.xrCutsceneSuspendTier;
 
     FILE* file = _fsopen(g_liveControlPath, "r", _SH_DENYNO);
     if (!file) return;
@@ -674,6 +680,11 @@ static void PollLiveControls() {
             xrPhysicalBodyRotation = intValue;
             continue;
         }
+        if (sscanf_s(line, "xr_cutscene_suspend_tier=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_cutscene_suspend_tier = %d", &intValue) == 1) {
+            xrCutsceneSuspendTier = intValue;
+            continue;
+        }
         if (sscanf_s(line, "xr_xinput_install=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_xinput_install = %d", &intValue) == 1) {
             xrXInputInstall = intValue;
@@ -768,6 +779,7 @@ static void PollLiveControls() {
     g_liveControls.xrMovementSource = xrMovementSource;
     g_liveControls.xrMovementControl = xrMovementSource != 0 ? 1 : 0;
     g_liveControls.xrPhysicalBodyRotation = xrPhysicalBodyRotation != 0 ? 1 : 0;
+    g_liveControls.xrCutsceneSuspendTier = (xrCutsceneSuspendTier < -1) ? -1 : (xrCutsceneSuspendTier > 4 ? 4 : xrCutsceneSuspendTier);
     g_liveControls.xrDisableMouseY = xrDisableMouseY != 0 ? 1 : 0;
     g_liveControls.xrXInputHook = xrXInputHook != 0 ? 1 : 0;
     g_liveControls.xrSnapTurn = xrSnapTurn != 0 ? 1 : 0;
@@ -834,6 +846,7 @@ static LiveControlsUiState MakeLiveControlsUiState() {
     state.xrSnapTurnAngleDeg = g_liveControls.xrSnapTurnAngleDeg;
     state.xrMovementSource = g_liveControls.xrMovementSource;
     state.xrPhysicalBodyRotation = g_liveControls.xrPhysicalBodyRotation;
+    state.xrCutsceneSuspendTier = g_liveControls.xrCutsceneSuspendTier;
     state.xrXInputInstall = g_liveControls.xrXInputInstall;
     state.xrInputActions = g_liveControls.xrInputActions;
     state.xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
@@ -886,6 +899,7 @@ static void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_snap_turn_angle_deg=%.2f\n", state.xrSnapTurnAngleDeg > 0.0f ? state.xrSnapTurnAngleDeg : 30.0f);
     fprintf(file, "xr_movement_source=%d\n", state.xrMovementSource < 0 ? 0 : (state.xrMovementSource > 3 ? 3 : state.xrMovementSource));
     fprintf(file, "xr_physical_body_rotation=%d\n", state.xrPhysicalBodyRotation != 0 ? 1 : 0);
+    fprintf(file, "xr_cutscene_suspend_tier=%d\n", state.xrCutsceneSuspendTier < -1 ? -1 : (state.xrCutsceneSuspendTier > 4 ? 4 : state.xrCutsceneSuspendTier));
     fprintf(file, "xr_xinput_install=%d\n", state.xrXInputInstall != 0 ? 1 : 0);
     fprintf(file, "xr_input_actions=%d\n", state.xrInputActions != 0 ? 1 : 0);
     fprintf(file, "xr_mono_xqueue_wait=%d\n", state.xrMonoXQueueWait != 0 ? 1 : 0);
@@ -945,6 +959,7 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
         g_liveControls.xrMovementControl = src != 0 ? 1 : 0;
     }
     g_liveControls.xrPhysicalBodyRotation = state->xrPhysicalBodyRotation != 0 ? 1 : 0;
+    g_liveControls.xrCutsceneSuspendTier = (state->xrCutsceneSuspendTier < -1) ? -1 : (state->xrCutsceneSuspendTier > 4 ? 4 : state->xrCutsceneSuspendTier);
     g_liveControls.xrDisableMouseY = state->xrDisableMouseY != 0 ? 1 : 0;
     g_liveControls.xrXInputHook = state->xrXInputHook != 0 ? 1 : 0;
     g_liveControls.xrSnapTurn = state->xrSnapTurn != 0 ? 1 : 0;
@@ -2837,6 +2852,17 @@ extern "C" void __fastcall OnLocateCameraCallback(float* rbxPtr, float xmm0_val)
             // the vehicle drives the puppet, body IK fights it and breaks the
             // character/camera position. Arms-only in vehicles.
             OpenXRManager::Get().SetSharedSlot(31, g_isInVehicle ? 1.0f : 0.0f);
+            // Cutscene VRIK-suspend threshold [158], encoded for the pose-apply hook: 0 = feature
+            // off, else (minTier + 1) so the hook suspends the body+arm solve while the CET-published
+            // scene tier [157] >= (this - 1). Only Tier2..Tier5 (stored 1..4) arm it -- a stored 0
+            // (zero-initialised before the ini loads) or -1 both publish 0, so there is no window
+            // where an uninitialised value could suspend normal gameplay. Republished each tick so a
+            // live overlay change (or a fresh mapping) is picked up without a restart.
+            {
+                const int susp = g_liveControls.xrCutsceneSuspendTier;
+                const float enc = (susp >= 1 && susp <= 4) ? static_cast<float>(susp + 1) : 0.0f;
+                OpenXRManager::Get().SetSharedSlot(158, enc);
+            }
         }
     }
     

--- a/src/vr/overlay/imgui_overlay.cpp
+++ b/src/vr/overlay/imgui_overlay.cpp
@@ -1012,6 +1012,41 @@ void DrawVRHandsControls() {
     }
 
     ImGui::Separator();
+    // Cutscene VRIK suspend (default: true cinematics). Picks the minimum scene tier at which the
+    // plugin fully suspends the body+arm solve so the engine's authored cinematic pose plays clean.
+    // Persisted via the LiveControls bridge (vrport.ini xr_cutscene_suspend_tier) and republished
+    // to shared[158] each tick by the runtime.
+    {
+        LiveControlsUiState st{};
+        GetLiveControlsUiState(&st);
+        // Combo index -> stored min-tier: Never(-1), Tier2+(1), Tier3+(2), Tier4+(3), Tier5(4).
+        static const int kTierValues[] = { -1, 1, 2, 3, 4 };
+        const char* kTierLabels[] = {
+            "Never (VRIK always on)",
+            "Staged scenes and up (Tier 2+)",
+            "Tier 3 and up",
+            "Cinematics (Tier 4+)  [default]",
+            "Full cinematics only (Tier 5)",
+        };
+        int cur = st.xrCutsceneSuspendTier;
+        int idx = 3; // default Tier4+
+        for (int i = 0; i < 5; ++i) { if (kTierValues[i] == cur) { idx = i; break; } }
+        ImGui::TextUnformatted("Suspend VRIK in cutscenes");
+        ImGui::SetNextItemWidth(280.0f);
+        if (ImGui::Combo("##cutsceneSuspend", &idx, kTierLabels, 5)) {
+            st.xrCutsceneSuspendTier = kTierValues[idx];
+            SetLiveControlsUiState(&st, 1);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("During scripted scenes the game plays a full authored body+arm animation.\n"
+                              "VRIK keeps solving on top of it, which looks wrong -- so above the chosen\n"
+                              "scene tier the avatar is left entirely to the engine's cutscene pose.\n"
+                              "'Cinematics (Tier 4+)' is the safe default; lower tiers also suspend during\n"
+                              "lighter staged/walk-and-talk moments. Vehicles use their own arms-only path.");
+        }
+    }
+
+    ImGui::Separator();
     ImGui::TextUnformatted("Hand IK Calibration (per hand: R = right, L = left)");
 
     // Defaults mirror the plugin's baked calibration (main.cpp globals).

--- a/src/vr/overlay/live_controls_ui.h
+++ b/src/vr/overlay/live_controls_ui.h
@@ -110,6 +110,10 @@ struct LiveControlsUiState {
     // camera to full head-look + head-relative movement). 0 (default) = classic
     // stick / snap-turn heading. Vehicles are unaffected either way. F10 -> VRIK tab.
     int xrPhysicalBodyRotation;
+    // Cutscene VRIK suspend. The minimum GameplayTier at which the plugin fully suspends the
+    // body+arm solve (leaving the engine's authored cinematic pose): -1 = never suspend, 0..4 =
+    // Tier1..Tier5. Default 3 (Tier4_FPPCinematic = true cinematics). F10 -> VRIK tab.
+    int xrCutsceneSuspendTier;
 };
 
 extern "C" void GetLiveControlsUiState(LiveControlsUiState* outState);


### PR DESCRIPTION
## What

Fully suspends the full-body VR avatar (VRIK) during scripted scenes / cinematics, with a tunable per-tier threshold in the F10 overlay.

## Why

During cutscenes the engine plays a fully authored body+arm animation. VRIK kept solving on top of it (controller-driven arms + `PlaceBodyUnderHMD` body), which fights the scene and makes the avatar look wrong. Previously only the in-vehicle case was special-cased (arms-only via shared slot `[31]`); there was no cutscene handling at all.

## How

- **Detection (CET):** `CyberpunkVRPort_VRIK/init.lua` reads the player's `PlayerStateMachine.SceneTier` blackboard (`GameplayTier`: 0 = Tier1_FullGameplay .. 3 = Tier4_FPPCinematic, 4 = Tier5_Cinematic) each frame and publishes it via a new native `SetVRSceneTier` into shared slot `[157]`.
- **Threshold (overlay):** new `xrCutsceneSuspendTier` LiveControl, persisted to `vrport.ini` (`xr_cutscene_suspend_tier`, default Tier4), exposed as a combo in **F10 -> VRIK** tab, and published encoded to shared slot `[158]`.
- **Suspend (hook):** `Hooked_AnimPoseApply` reads raw `[157]`/`[158]` right after the seqlock latch and returns before any bone write while `tier >= threshold`, leaving the engine's native cinematic pose untouched. It bails *after* `++g_AnimPoseMatchCalls` so the CET desync detector stays healthy and does not re-arm during the scene.

## Design notes

- Encoding makes an uninitialised `[158]` (== 0) mean "off", so there is no startup window where gameplay could be suspended.
- Reads raw `g_pSharedHands[157/158]` (not `SharedPose`) because the seqlock snapshot only latches `[0..126]`.
- Vehicles keep their existing separate arms-only path.
- Slots `[157]`/`[158]` documented in `src/common/shared_slots.h` (the frozen slot map).

## Testing

Built both plugins and ran in-game (CP2077 2.31, Quest 3). The avatar no longer fights cutscene animation; the F10 tier picker switches live without a restart.

<a href="https://youtube.com/shorts/saFuCoCBU6s"><img width="1035" height="1038" alt="image" src="https://github.com/user-attachments/assets/35ad6f95-752e-4a5c-b5e8-e572cf21bcfb" /></a>



