### PR TITLE
Raycast-based laser dot

### DIFF
--- a/include/Core/LiveControls.hpp
+++ b/include/Core/LiveControls.hpp
@@ -46,6 +46,7 @@ struct LiveControls {
     volatile int xrSnapTurn;        // 1 = discrete snap turn from right-stick X
     volatile float xrSnapTurnAngleDeg; // degrees per snap pulse
     volatile int xrMovementSource;  // 0 = Game, 1 = HMD, 2 = LeftHand, 3 = RightHand
+    volatile int xrLaserDotMode = 1; // 0 = steady projection, 1 = real world point, 2 = surface raycast
     volatile int xrXInputInstall;   // 1 = install the XInput entry-point detour at startup (default 1, set 0 in vrport.ini to fully bypass)
     volatile int xrInputActions;    // 1 = create gameplay XrActions (thumbstick/trigger/buttons). 0 = pose-only legacy behaviour
     volatile int xrMonoXQueueWait;  // 1 = mono path inserts cross-queue Wait before depth capture (legacy). 0 = skip it -- avoids CP2077 async-compute Wait cycle that froze present thread.

--- a/include/Natives/NativeFunctions.hpp
+++ b/include/Natives/NativeFunctions.hpp
@@ -135,6 +135,8 @@ void VRScannerSlotSet(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32
 void VRScannerSlotSave(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t);
 // 1 while a device screen (computer, terminal) is up; lets the right stick's Y reach the game's UI.
 void SetVRDeviceScreen(RED4ext::IScriptable* aContext, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t a4);
+void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);
+void QueryVRNpcHitSurface(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, RED4ext::Vector4* aOut, int64_t);
 void SetVRMuzzlePos(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);
 void SetVRMuzzleQuat(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);
 void SetVRPairLead(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);

--- a/include/Overlay/LiveControlsUi.hpp
+++ b/include/Overlay/LiveControlsUi.hpp
@@ -46,6 +46,8 @@ struct LiveControlsUiState {
     // 0..3 enum (0=Game, 1=HMD, 2=LeftHand, 3=RightHand). The overlay edits the
     // latter and the proxy mirrors it back into the legacy field.
     int xrMovementSource;
+    // Laser dot projection mode. 0 = steady projection, 1 = real world point, 2 = surface raycast.
+    int xrLaserDotMode;
     // Kill-switches for the new controller pipeline; default 0 (off) so a stuck
     // OpenXR binding or XInput entry-point patch can't keep CP2077 from booting.
     int xrXInputInstall;

--- a/include/Stereo/StereoInternal.hpp
+++ b/include/Stereo/StereoInternal.hpp
@@ -489,6 +489,7 @@ extern "C" float    CyberpunkVR_BarrelDotNdcX2;
 extern "C" float    CyberpunkVR_BarrelDotNdcY;
 extern "C" float    CyberpunkVR_BarrelDotRadiusPx;
 extern "C" int      CyberpunkVR_BarrelDotSecondEye;
+extern "C" int      CyberpunkVR_BarrelDotSecondVisible;
 extern "C" unsigned long long CyberpunkVR_BarrelDotTick;
 extern D3D12_CPU_DESCRIPTOR_HANDLE g_own_rtv;
 extern DXGI_FORMAT           g_d12_fmt;

--- a/include/Utils/SharedSlots.hpp
+++ b/include/Utils/SharedSlots.hpp
@@ -83,6 +83,9 @@
 //  [152]      [CAMWRITE] Lua ack (= last [151] applied via SetVRCamAck)  Lua -> dxgi
 //  [153]      [CAMWRITE] entity world yaw (deg)  plugin (SetVRPlayerYaw batch) -> dxgi
 //             (mode-1 heading source: the camera quat can't serve once WE compose it)
+//  [167..169] barrel ray hit world XYZ          plugin (CET push) -> overlay
+//  [170]      barrel ray hit valid              plugin (CET push) -> overlay
+//  [171]      barrel ray packet seqlock         plugin (CET push) -> overlay
 //             ONE-TICK VIEW HOLD protocol (v3, trace-proven mechanism): the entity/
 //             puppet world yaw applies one TICK after the camera turns; sprint locks
 //             puppet yaw to the heading, so the animated body+arms rendered one frame
@@ -206,4 +209,10 @@ constexpr int kWheelArmedMask     = 163;
 constexpr int kDeviceScreenOpen   = 164;
 constexpr int kWheelArmedRightBit = 1;
 constexpr int kWheelArmedLeftBit  = 2;
+// MUZZLE LASER RAYCAST. CET owns the physics query on the script/game thread; the overlay only
+// consumes its world-space hit. [171] brackets XYZ+valid so the render thread cannot combine
+// values from different CET updates. A fresh valid=0 packet deliberately selects direction mode.
+constexpr int kBarrelRayHitX     = 167;   // ..169 world-space hit XYZ
+constexpr int kBarrelRayHitValid = 170;   // 1 = hit, 0 = miss
+constexpr int kBarrelRaySeq      = 171;   // odd while writing, even when coherent
 } // namespace vrshared

--- a/include/Utils/SharedSlots.hpp
+++ b/include/Utils/SharedSlots.hpp
@@ -86,6 +86,11 @@
 //  [167..169] barrel ray hit world XYZ          plugin (CET push) -> overlay
 //  [170]      barrel ray hit valid              plugin (CET push) -> overlay
 //  [171]      barrel ray packet seqlock         plugin (CET push) -> overlay
+//  [172..174] barrel MAIN-eye world XYZ         overlay -> CET
+//  [175..177] barrel second-eye world XYZ       overlay -> CET
+//  [178]      barrel eye-origin packet seqlock  overlay -> CET
+//  [179..180] barrel dot visible MAIN/second    plugin (CET push) -> overlay; bracketed by [171]
+//  [181]      mode-2 laser dot active           overlay -> CET
 //             ONE-TICK VIEW HOLD protocol (v3, trace-proven mechanism): the entity/
 //             puppet world yaw applies one TICK after the camera turns; sprint locks
 //             puppet yaw to the heading, so the animated body+arms rendered one frame
@@ -210,9 +215,19 @@ constexpr int kDeviceScreenOpen   = 164;
 constexpr int kWheelArmedRightBit = 1;
 constexpr int kWheelArmedLeftBit  = 2;
 // MUZZLE LASER RAYCAST. CET owns the physics query on the script/game thread; the overlay only
-// consumes its world-space hit. [171] brackets XYZ+valid so the render thread cannot combine
-// values from different CET updates. A fresh valid=0 packet deliberately selects direction mode.
+// consumes its world-space hit and visibility. [171] brackets XYZ+valid+[179..180] so the render
+// thread cannot combine values from different CET updates. A fresh valid=0 packet deliberately
+// selects direction mode while retaining that update's per-eye visibility.
 constexpr int kBarrelRayHitX     = 167;   // ..169 world-space hit XYZ
 constexpr int kBarrelRayHitValid = 170;   // 1 = hit, 0 = miss
 constexpr int kBarrelRaySeq      = 171;   // odd while writing, even when coherent
+// The eye names follow the two actual draw paths rather than assuming MAIN is always the physical
+// left eye. DrawBarrelCrosshair can swap MAIN's eye sign; publishing MAIN/second keeps visibility
+// attached to the texture that consumes it.
+constexpr int kBarrelMainEyeX       = 172;   // ..174 world-space eye XYZ
+constexpr int kBarrelSecondEyeX     = 175;   // ..177 world-space eye XYZ
+constexpr int kBarrelEyeSeq         = 178;   // odd while writing, even when coherent
+constexpr int kBarrelMainVisible    = 179;   // 1 = clear/fail-open, 0 = occluded
+constexpr int kBarrelSecondVisible  = 180;   // 1 = clear/fail-open, 0 = occluded
+constexpr int kBarrelRayActive      = 181;   // checkbox on + mode 2 + weapon equipped
 } // namespace vrshared

--- a/mods/cet/CyberpunkVRPort_Weapon/init.lua
+++ b/mods/cet/CyberpunkVRPort_Weapon/init.lua
@@ -414,19 +414,170 @@ end
 -- the physical-reload raycast in this tree. Keep physics out of the DXGI Present path.
 local BARREL_RAY_MAX_M = 1000.0
 local BARREL_RAY_PRESET = 'Sight Blocker'
+local BARREL_LOS_ENDPOINT_OFFSET_M = 0.005
+local BARREL_LOS_GLASS_STEP_M = 0.005
+local BARREL_LOS_MAX_GLASS_HITS = 8
+local BARREL_EYE_MAX_AGE_S = 0.020
 local barrelRaySystem = nil
 local barrelRayCallWarned = false
 local barrelNpcCallWarned = false
+local barrelLosCallWarned = false
+local barrelEyeLastSeq = 0
+local barrelEyeAgeS = math.huge
+local barrelLosLogAt = -1.0
+local barrelRayWasActive = false
 
-local function publishBarrelRayMiss()
+local function publishBarrelRayMiss(mainVisible, secondVisible)
     if type(SetVRBarrelRayHit) == 'function' then
-        SetVRBarrelRayHit(0.0, 0.0, 0.0, 0)
+        SetVRBarrelRayHit(0.0, 0.0, 0.0, 0,
+            mainVisible == false and 0 or 1,
+            secondVisible == false and 0 or 1)
     end
 end
 
-local function updateBarrelRay()
+local function stopBarrelRay()
+    if barrelRayWasActive then
+        publishBarrelRayMiss()
+        barrelRayWasActive = false
+    end
+end
+
+-- Read the two eye origins as one render-side snapshot. A missing or stale packet disables only
+-- occlusion (fail-open); it never disables the existing mode-2 hit provider or direction marker.
+local function readBarrelEyes(dt)
+    barrelEyeAgeS = barrelEyeAgeS + math.max(dt or 0.0, 0.0)
+    for _ = 1, 3 do
+        local s0 = math.floor(GetVRSharedSlot(178) or 0.0)
+        if s0 > 0 and s0 % 2 == 0 then
+            local mx, my, mz = GetVRSharedSlot(172), GetVRSharedSlot(173), GetVRSharedSlot(174)
+            local sx, sy, sz = GetVRSharedSlot(175), GetVRSharedSlot(176), GetVRSharedSlot(177)
+            local s1 = math.floor(GetVRSharedSlot(178) or 0.0)
+            if s0 == s1 and s1 % 2 == 0 then
+                if s1 ~= barrelEyeLastSeq then
+                    barrelEyeLastSeq = s1
+                    barrelEyeAgeS = 0.0
+                end
+                local mainLen2 = mx*mx + my*my + mz*mz
+                local secondLen2 = sx*sx + sy*sy + sz*sz
+                local ex, ey, ez = mx - sx, my - sy, mz - sz
+                local separation2 = ex*ex + ey*ey + ez*ez
+                if barrelEyeAgeS <= BARREL_EYE_MAX_AGE_S and mainLen2 > 1.0 and
+                   secondLen2 > 1.0 and separation2 > 0.0001 and separation2 < 0.04 then
+                    return Vector4.new(mx, my, mz, 1.0), Vector4.new(sx, sy, sz, 1.0)
+                end
+                return nil, nil
+            end
+        end
+    end
+    return nil, nil
+end
+
+local function makeBarrelLosEnd(eye, finalHit, fx, fy, fz)
+    if finalHit then
+        local dx, dy, dz = finalHit.x - eye.x, finalHit.y - eye.y, finalHit.z - eye.z
+        local d2 = dx*dx + dy*dy + dz*dz
+        if d2 <= BARREL_LOS_ENDPOINT_OFFSET_M * BARREL_LOS_ENDPOINT_OFFSET_M then
+            return nil
+        end
+        local invD = 1.0 / math.sqrt(d2)
+        return Vector4.new(
+            finalHit.x - dx * invD * BARREL_LOS_ENDPOINT_OFFSET_M,
+            finalHit.y - dy * invD * BARREL_LOS_ENDPOINT_OFFSET_M,
+            finalHit.z - dz * invD * BARREL_LOS_ENDPOINT_OFFSET_M,
+            1.0)
+    end
+    -- A finite physics segment tests visibility only. The rendered fallback remains optical
+    -- infinity; each eye gets its own parallel segment along the same muzzle direction.
+    return Vector4.new(eye.x + fx * BARREL_RAY_MAX_M,
+                       eye.y + fy * BARREL_RAY_MAX_M,
+                       eye.z + fz * BARREL_RAY_MAX_M, 1.0)
+end
+
+local function barrelDotVisibleFromEye(player, eye, finalHit, fx, fy, fz)
+    local rayEnd = makeBarrelLosEnd(eye, finalHit, fx, fy, fz)
+    if not rayEnd then return true, 0.0, 'near' end
+
+    -- Use the same world collision semantics already validated by the muzzle provider. The first
+    -- probe's generic QueryFilter missed vehicles and added no proven coverage. Glass materials are
+    -- transparent to the dot LOS: step through each glass hit on the same segment rather than
+    -- declaring the whole remaining segment clear and missing an opaque blocker behind the pane.
+    local dx, dy, dz = rayEnd.x - eye.x, rayEnd.y - eye.y, rayEnd.z - eye.z
+    local rayLengthSq = dx*dx + dy*dy + dz*dz
+    if rayLengthSq <= 0.000001 then return true, 0.0, 'near' end
+    local invRayLength = 1.0 / math.sqrt(rayLengthSq)
+    local dirX, dirY, dirZ = dx * invRayLength, dy * invRayLength, dz * invRayLength
+    local worldStart = eye
+    local glassHits = 0
+    for _ = 1, BARREL_LOS_MAX_GLASS_HITS + 1 do
+        local worldOk, worldSuccess, worldResult = pcall(function()
+            return barrelRaySystem:SyncRaycastByQueryPreset(
+                worldStart, rayEnd, BARREL_RAY_PRESET, false)
+        end)
+        if not worldOk then
+            if not barrelLosCallWarned then
+                barrelLosCallWarned = true
+                logAlways('barrel world LOS failed; visibility remains fail-open: %s',
+                    tostring(worldSuccess))
+            end
+            return true, -1.0, 'world-error'
+        end
+        if not (worldSuccess and worldResult and worldResult.position) then
+            break
+        end
+
+        local p = worldResult.position
+        local materialName = string.lower(tostring(worldResult.material or ''))
+        if not string.find(materialName, 'glass', 1, true) then
+            local bx, by, bz = p.x - eye.x, p.y - eye.y, p.z - eye.z
+            return false, math.sqrt(bx*bx + by*by + bz*bz), 'world'
+        end
+
+        glassHits = glassHits + 1
+        if glassHits > BARREL_LOS_MAX_GLASS_HITS then
+            break
+        end
+        worldStart = Vector4.new(
+            p.x + dirX * BARREL_LOS_GLASS_STEP_M,
+            p.y + dirY * BARREL_LOS_GLASS_STEP_M,
+            p.z + dirZ * BARREL_LOS_GLASS_STEP_M,
+            1.0)
+        local rx, ry, rz = rayEnd.x - worldStart.x, rayEnd.y - worldStart.y,
+                           rayEnd.z - worldStart.z
+        if rx*dirX + ry*dirY + rz*dirZ <= 0.0 then
+            break
+        end
+    end
+
+    -- Sight Blocker intentionally ignores character bodies. Only after the world segment is clear
+    -- ask the already-validated official HitRepresentation provider whether an NPC blocks it.
+    local npcOk, npcResult = pcall(function()
+        if not player or not player.VRFindNpcBarrelRayHit then return nil end
+        return player:VRFindNpcBarrelRayHit(eye, rayEnd)
+    end)
+    if not npcOk then
+        if not barrelLosCallWarned then
+            barrelLosCallWarned = true
+            logAlways('barrel NPC LOS failed; visibility remains fail-open: %s',
+                tostring(npcResult))
+        end
+        return true, -1.0, 'npc-error'
+    end
+    if npcResult and (npcResult.w or 0.0) > 0.5 then
+        local dx, dy, dz = npcResult.x - eye.x, npcResult.y - eye.y, npcResult.z - eye.z
+        return false, math.sqrt(dx*dx + dy*dy + dz*dz),
+            glassHits > 0 and ('npc-glass' .. tostring(glassHits)) or 'npc'
+    end
+    return true, -1.0, glassHits > 0 and ('clear-glass' .. tostring(glassHits)) or 'clear'
+end
+
+local function updateBarrelRay(dt)
     if type(GetVRSharedSlot) ~= 'function' then return end
     if type(SetVRBarrelRayHit) ~= 'function' then return end
+    if GetVRSharedSlot(181) < 0.5 then
+        stopBarrelRay()
+        return
+    end
+    barrelRayWasActive = true
     if GetVRSharedSlot(27) < 0.5 or GetVRSharedSlot(203) < 0.5 then
         publishBarrelRayMiss()
         return
@@ -471,9 +622,9 @@ local function updateBarrelRay()
     -- Ray B uses the exact same from/to and has no cross-frame cache: W=0 is an immediate miss.
     -- Targeting supplies and deduplicates candidates in redscript; native HitRepresentation gives
     -- the closest animated body-surface enter point for each candidate.
+    local player = Game.GetPlayer()
     local npcHit, npcDistanceSq = nil, nil
     local npcOk, npcResult = pcall(function()
-        local player = Game.GetPlayer()
         if not player or not player.VRFindNpcBarrelRayHit then return nil end
         return player:VRFindNpcBarrelRayHit(from, to)
     end)
@@ -497,12 +648,35 @@ local function updateBarrelRay()
     if npcHit and (not finalDistanceSq or npcDistanceSq < finalDistanceSq) then
         finalHit, finalDistanceSq = npcHit, npcDistanceSq
     end
+
+    local mainVisible, secondVisible = true, true
+    local mainBlockM, secondBlockM = -1.0, -1.0
+    local mainSource, secondSource = 'no-eyes', 'no-eyes'
+    local mainEye, secondEye = readBarrelEyes(dt)
+    if player and mainEye and secondEye then
+        mainVisible, mainBlockM, mainSource = barrelDotVisibleFromEye(
+            player, mainEye, finalHit, fx, fy, fz)
+        secondVisible, secondBlockM, secondSource = barrelDotVisibleFromEye(
+            player, secondEye, finalHit, fx, fy, fz)
+    end
+    if vrDebug() then
+        local now = (os and os.clock and os.clock()) or 0.0
+        if now - barrelLosLogAt >= 1.0 then
+            barrelLosLogAt = now
+            logAlways('barrel LOS: eyes=%d hit=%d main=%s/%s block=%.3fm second=%s/%s block=%.3fm',
+                (mainEye and secondEye) and 1 or 0,
+                finalHit and 1 or 0,
+                mainVisible and 'clear' or 'blocked', mainSource, mainBlockM,
+                secondVisible and 'clear' or 'blocked', secondSource, secondBlockM)
+        end
+    end
     if finalHit then
-        SetVRBarrelRayHit(finalHit.x, finalHit.y, finalHit.z, 1)
+        SetVRBarrelRayHit(finalHit.x, finalHit.y, finalHit.z, 1,
+            mainVisible and 1 or 0, secondVisible and 1 or 0)
         return
     end
 
-    publishBarrelRayMiss()
+    publishBarrelRayMiss(mainVisible, secondVisible)
 end
 
 registerForEvent('onInit', function()
@@ -543,7 +717,7 @@ registerForEvent('onUpdate', function(dt)
         -- newcomer gets its own pcall.
         if wpn then updateMuzzle(wpn) end
         local okRay, errRay = pcall(function()
-            if wpn then updateBarrelRay() else publishBarrelRayMiss() end
+            if wpn then updateBarrelRay(dt) else stopBarrelRay() end
         end)
         if not okRay then
             publishBarrelRayMiss()

--- a/mods/cet/CyberpunkVRPort_Weapon/init.lua
+++ b/mods/cet/CyberpunkVRPort_Weapon/init.lua
@@ -409,6 +409,102 @@ local function updateMuzzle(wpn)
     end
 end
 
+-- Trace the weapon's bore against world collision on CET's game-script side. The current
+-- CET/CP2077 build exposes the hit as TraceResult.position; this same contract is already used by
+-- the physical-reload raycast in this tree. Keep physics out of the DXGI Present path.
+local BARREL_RAY_MAX_M = 1000.0
+local BARREL_RAY_PRESET = 'Sight Blocker'
+local barrelRaySystem = nil
+local barrelRayCallWarned = false
+local barrelNpcCallWarned = false
+
+local function publishBarrelRayMiss()
+    if type(SetVRBarrelRayHit) == 'function' then
+        SetVRBarrelRayHit(0.0, 0.0, 0.0, 0)
+    end
+end
+
+local function updateBarrelRay()
+    if type(GetVRSharedSlot) ~= 'function' then return end
+    if type(SetVRBarrelRayHit) ~= 'function' then return end
+    if GetVRSharedSlot(27) < 0.5 or GetVRSharedSlot(203) < 0.5 then
+        publishBarrelRayMiss()
+        return
+    end
+
+    local px, py, pz = GetVRSharedSlot(200), GetVRSharedSlot(201), GetVRSharedSlot(202)
+    local fx, fy, fz = GetVRSharedSlot(24), GetVRSharedSlot(25), GetVRSharedSlot(26)
+    local f2 = fx * fx + fy * fy + fz * fz
+    if px * px + py * py + pz * pz < 1.0 or f2 < 0.25 then
+        publishBarrelRayMiss()
+        return
+    end
+
+    local invF = 1.0 / math.sqrt(f2)
+    fx, fy, fz = fx * invF, fy * invF, fz * invF
+    local from = Vector4.new(px, py, pz, 1.0)
+    local to = Vector4.new(px + fx * BARREL_RAY_MAX_M,
+                           py + fy * BARREL_RAY_MAX_M,
+                           pz + fz * BARREL_RAY_MAX_M, 1.0)
+    if barrelRaySystem == nil then
+        barrelRaySystem = Game.GetSpatialQueriesSystem() or false
+    end
+    if not barrelRaySystem then
+        publishBarrelRayMiss()
+        return
+    end
+
+    -- Sight Blocker with dynamic collision covers world, props, vehicles and glass without
+    -- self-hitting the tested player hands or weapons. NPC body surfaces use Ray B below.
+    local worldHit, worldDistanceSq = nil, nil
+    local success, result = barrelRaySystem:SyncRaycastByQueryPreset(
+        from, to, BARREL_RAY_PRESET, false)
+    if success and result then
+        local p = result.position
+        if p and type(p.x) == 'number' and type(p.y) == 'number' and type(p.z) == 'number' then
+            local dx, dy, dz = p.x - px, p.y - py, p.z - pz
+            worldHit = p
+            worldDistanceSq = dx * dx + dy * dy + dz * dz
+        end
+    end
+
+    -- Ray B uses the exact same from/to and has no cross-frame cache: W=0 is an immediate miss.
+    -- Targeting supplies and deduplicates candidates in redscript; native HitRepresentation gives
+    -- the closest animated body-surface enter point for each candidate.
+    local npcHit, npcDistanceSq = nil, nil
+    local npcOk, npcResult = pcall(function()
+        local player = Game.GetPlayer()
+        if not player or not player.VRFindNpcBarrelRayHit then return nil end
+        return player:VRFindNpcBarrelRayHit(from, to)
+    end)
+    if npcOk then
+        if npcResult and (npcResult.w or 0.0) > 0.5 and
+           type(npcResult.x) == 'number' and type(npcResult.y) == 'number' and
+           type(npcResult.z) == 'number' then
+            local dx, dy, dz = npcResult.x - px, npcResult.y - py, npcResult.z - pz
+            npcHit = npcResult
+            npcDistanceSq = dx * dx + dy * dy + dz * dz
+        end
+    else
+        if not barrelNpcCallWarned then
+            barrelNpcCallWarned = true
+            logAlways('barrel ray: NPC surface query failed; Ray A remains active: %s',
+                tostring(npcResult))
+        end
+    end
+
+    local finalHit, finalDistanceSq = worldHit, worldDistanceSq
+    if npcHit and (not finalDistanceSq or npcDistanceSq < finalDistanceSq) then
+        finalHit, finalDistanceSq = npcHit, npcDistanceSq
+    end
+    if finalHit then
+        SetVRBarrelRayHit(finalHit.x, finalHit.y, finalHit.z, 1)
+        return
+    end
+
+    publishBarrelRayMiss()
+end
+
 registerForEvent('onInit', function()
     logf("weapon-aim init")
 end)
@@ -446,6 +542,16 @@ registerForEvent('onUpdate', function(dt)
         -- immediately. Isolation belongs in the OTHER direction: the muzzle keeps its place and the
         -- newcomer gets its own pcall.
         if wpn then updateMuzzle(wpn) end
+        local okRay, errRay = pcall(function()
+            if wpn then updateBarrelRay() else publishBarrelRayMiss() end
+        end)
+        if not okRay then
+            publishBarrelRayMiss()
+            if not barrelRayCallWarned then
+                barrelRayCallWarned = true
+                logAlways('barrel ray: query failed: %s', tostring(errRay))
+            end
+        end
         if wpn then
             local wid = nil
             pcall(function() wid = tostring(wpn:GetEntityID().hash) end)

--- a/mods/redscript/CyberpunkVRPort_Melee/vrport_npc_ray_natives.reds
+++ b/mods/redscript/CyberpunkVRPort_Melee/vrport_npc_ray_natives.reds
@@ -1,0 +1,64 @@
+// CyberpunkVRPort -- global native declaration for the NPC hit-representation surface query.
+//
+// This file intentionally has no module declaration. The plugin registers a plain global
+// QueryVRNpcHitSurface; declaring it inside CyberpunkVRPort.Melee would make redscript look for a
+// module-qualified native that does not exist.
+
+native func QueryVRNpcHitSurface(entity: ref<GameObject>, from: Vector4, to: Vector4) -> Vector4;
+
+// Find the closest NPC body surface on the current muzzle ray. Targeting only supplies nearby
+// candidates; the native query intersects each unique entity's live animated HitRepresentation.
+@addMethod(PlayerPuppet)
+public func VRFindNpcBarrelRayHit(rayStart: Vector4, rayEnd: Vector4) -> Vector4 {
+  let q: TargetSearchQuery;
+  q.testedSet = TargetingSet.Complete;
+  q.searchFilter = TSF_NPC();
+  q.maxDistance = 60.0;
+  q.filterObjectByDistance = true;
+  q.ignoreInstigator = true;
+  let parts: array<TS_TargetPartInfo>;
+  GameInstance.GetTargetingSystem(this.GetGame()).GetTargetParts(this, q, parts);
+
+  let seen: array<EntityID>;
+  let best = new Vector4(0.0, 0.0, 0.0, 0.0);
+  let bestDistanceSq = 999999999.0;
+  let i = 0;
+  while i < ArraySize(parts) {
+    let comp = TS_TargetPartInfo.GetComponent(parts[i]);
+    if IsDefined(comp) {
+      let ent = comp.GetEntity() as GameObject;
+      if IsDefined(ent) {
+        let entityId = ent.GetEntityID();
+        let duplicate = false;
+        let j = 0;
+        while j < ArraySize(seen) {
+          if seen[j] == entityId { duplicate = true; };
+          j += 1;
+        };
+        if !duplicate {
+          ArrayPush(seen, entityId);
+          let hit = QueryVRNpcHitSurface(ent, rayStart, rayEnd);
+          if hit.W > 0.5 {
+            let dx = hit.X - rayStart.X;
+            let dy = hit.Y - rayStart.Y;
+            let dz = hit.Z - rayStart.Z;
+            let distanceSq = dx*dx + dy*dy + dz*dz;
+            if distanceSq < bestDistanceSq {
+              bestDistanceSq = distanceSq;
+              best = hit;
+            };
+          };
+        };
+      };
+    };
+    i += 1;
+  };
+  if best.W < 0.5 {
+    if ArraySize(parts) == 0 {
+      best.W = -1.0; // TargetingSystem returned no NPC target parts.
+    } else {
+      best.W = -3.0; // Unique NPC candidates existed, but no body surface intersected.
+    };
+  };
+  return best;
+}

--- a/src/Core/LauncherConfig.cpp
+++ b/src/Core/LauncherConfig.cpp
@@ -182,6 +182,7 @@ void EnsureLiveControlFileExists() {
     fprintf(file, "xr_snap_turn=0\n");
     fprintf(file, "xr_snap_turn_angle_deg=30\n");
     fprintf(file, "xr_movement_source=0\n");
+    fprintf(file, "xr_laser_dot_mode=1\n");
     // Default ON for the gameplay-input pipeline: both flags are required for the
     // VR controller to reach CP2077 as an XInput pad (otherwise the game detects no
     // controller and shows keyboard glyphs). Set either to 0 in vrport.ini if a
@@ -246,4 +247,3 @@ void SaveLauncherConfig(int width, int height) {
     fprintf(file, "debug=%d\n", g_launcherDebug);
     fclose(file);
 }
-

--- a/src/Core/LiveControlsPoll.cpp
+++ b/src/Core/LiveControlsPoll.cpp
@@ -220,6 +220,7 @@ void PollLiveControls() {
     };
     float xrSnapTurnAngleDeg = g_liveControls.xrSnapTurnAngleDeg > 0.0f ? g_liveControls.xrSnapTurnAngleDeg : 30.0f;
     int xrMovementSource = g_liveControls.xrMovementSource;
+    int xrLaserDotMode = g_liveControls.xrLaserDotMode;
     int xrXInputInstall = g_liveControls.xrXInputInstall;
     int xrInputActions = g_liveControls.xrInputActions;
     int xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
@@ -478,6 +479,11 @@ void PollLiveControls() {
             xrMovementSource = intValue;
             continue;
         }
+        if (sscanf_s(line, "xr_laser_dot_mode=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_laser_dot_mode = %d", &intValue) == 1) {
+            xrLaserDotMode = intValue;
+            continue;
+        }
         if (sscanf_s(line, "xr_cutscene_suspend_tier=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_cutscene_suspend_tier = %d", &intValue) == 1) {
             xrCutsceneSuspendTier = intValue;
@@ -635,6 +641,7 @@ void PollLiveControls() {
     // means VR-driven so map to legacy 1).
     if (xrMovementSource < 0 || xrMovementSource > 3) xrMovementSource = xrMovementControl != 0 ? 1 : 0;
     g_liveControls.xrMovementSource = xrMovementSource;
+    g_liveControls.xrLaserDotMode = (xrLaserDotMode < 0) ? 0 : (xrLaserDotMode > 2 ? 2 : xrLaserDotMode);
     g_liveControls.xrMovementControl = xrMovementSource != 0 ? 1 : 0;
     g_liveControls.xrPhysicalBodyRotation = xrPhysicalBodyRotation != 0 ? 1 : 0;
     g_liveControls.xrCutsceneSuspendTier =
@@ -771,6 +778,7 @@ LiveControlsUiState MakeLiveControlsUiState() {
     state.xrSnapTurn = g_liveControls.xrSnapTurn;
     state.xrSnapTurnAngleDeg = g_liveControls.xrSnapTurnAngleDeg;
     state.xrMovementSource = g_liveControls.xrMovementSource;
+    state.xrLaserDotMode = g_liveControls.xrLaserDotMode;
     state.xrPhysicalBodyRotation = g_liveControls.xrPhysicalBodyRotation;
     state.xrCutsceneSuspendTier = g_liveControls.xrCutsceneSuspendTier;
     state.xrXInputInstall = g_liveControls.xrXInputInstall;
@@ -855,6 +863,7 @@ void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_snap_turn=%d\n", state.xrSnapTurn != 0 ? 1 : 0);
     fprintf(file, "xr_snap_turn_angle_deg=%.2f\n", state.xrSnapTurnAngleDeg > 0.0f ? state.xrSnapTurnAngleDeg : 30.0f);
     fprintf(file, "xr_movement_source=%d\n", state.xrMovementSource < 0 ? 0 : (state.xrMovementSource > 3 ? 3 : state.xrMovementSource));
+    fprintf(file, "xr_laser_dot_mode=%d\n", state.xrLaserDotMode < 0 ? 0 : (state.xrLaserDotMode > 2 ? 2 : state.xrLaserDotMode));
     fprintf(file, "xr_physical_body_rotation=%d\n", state.xrPhysicalBodyRotation != 0 ? 1 : 0);
     fprintf(file, "xr_cutscene_suspend_tier=%d\n",
             state.xrCutsceneSuspendTier < -1 ? -1 : (state.xrCutsceneSuspendTier > 4 ? 4 : state.xrCutsceneSuspendTier));
@@ -927,6 +936,8 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
         g_liveControls.xrMovementSource = src;
         g_liveControls.xrMovementControl = src != 0 ? 1 : 0;
     }
+    g_liveControls.xrLaserDotMode =
+        (state->xrLaserDotMode < 0) ? 0 : (state->xrLaserDotMode > 2 ? 2 : state->xrLaserDotMode);
     g_liveControls.xrPhysicalBodyRotation = state->xrPhysicalBodyRotation != 0 ? 1 : 0;
     g_liveControls.xrCutsceneSuspendTier =
         (state->xrCutsceneSuspendTier < -1) ? -1

--- a/src/Natives/OrientationProvider.cpp
+++ b/src/Natives/OrientationProvider.cpp
@@ -664,14 +664,18 @@ void SetVRMuzzleQuat(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*,
 }
 
 // Publish CET's muzzle raycast result without performing a game-world query from Present. The
-// sequence brackets four independent float stores so the render thread only consumes one update.
+// sequence brackets the hit and per-eye visibility stores so the render thread consumes one update.
 void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t) {
     float x = 0.0f, y = 0.0f, z = 0.0f;
     int32_t valid = 0;
+    int32_t mainVisible = 1;
+    int32_t secondVisible = 1;
     RED4ext::GetParameter(aFrame, &x);
     RED4ext::GetParameter(aFrame, &y);
     RED4ext::GetParameter(aFrame, &z);
     RED4ext::GetParameter(aFrame, &valid);
+    RED4ext::GetParameter(aFrame, &mainVisible);
+    RED4ext::GetParameter(aFrame, &secondVisible);
     aFrame->code++;
     EnsureSharedMemory();
     if (!g_pSharedHands) return;
@@ -687,6 +691,8 @@ void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void
     g_pSharedHands[vrshared::kBarrelRayHitX + 1] = y;
     g_pSharedHands[vrshared::kBarrelRayHitX + 2] = z;
     g_pSharedHands[vrshared::kBarrelRayHitValid] = valid != 0 ? 1.0f : 0.0f;
+    g_pSharedHands[vrshared::kBarrelMainVisible] = mainVisible != 0 ? 1.0f : 0.0f;
+    g_pSharedHands[vrshared::kBarrelSecondVisible] = secondVisible != 0 ? 1.0f : 0.0f;
     std::atomic_thread_fence(std::memory_order_release);
     g_pSharedHands[vrshared::kBarrelRaySeq] = static_cast<float>(nextEven);
     s_evenSeq = nextEven;
@@ -1035,4 +1041,3 @@ void ResetVRProvCounts(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void
     g_provOverrides = 0;
     for (int i = 0; i < 4; ++i) { g_provLastQ[i]=0; g_provOrigQ[i]=0; g_provCtrlQ[i]=0; g_provHmdQ[i]=0; }
 }
-

--- a/src/Natives/OrientationProvider.cpp
+++ b/src/Natives/OrientationProvider.cpp
@@ -5,6 +5,7 @@
 // register rather than guessing what passes through it.
 #include <RED4ext/RED4ext.hpp>
 #include <RED4ext/GameEngine.hpp>
+#include <atomic>
 #include <sstream>
 #include <locale>
 #include <clocale>
@@ -48,15 +49,19 @@
 #include <RED4ext/Scripting/Natives/entAnimationControllerComponent.hpp>
 #include <RED4ext/Scripting/Natives/Generated/ent/GarmentSkinnedMeshComponent.hpp>
 #include <RED4ext/Scripting/Natives/Generated/ent/MeshComponent.hpp>
+#include <RED4ext/Scripting/Natives/Generated/game/HitRepresentationComponent.hpp>
+#include <RED4ext/Scripting/Natives/Generated/game/HitShapeUserData.hpp>
+#include <RED4ext/Scripting/Natives/Generated/game/QueryResult.hpp>
 #include <windows.h>
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstring>
-#include <atomic>
 #include <cstdint>
 #include <fstream>
 #include <utility>
 #include <iomanip>
+#include <limits>
 #include <string>
 #include "Anim/VrikHook.hpp"
 #include "Anim/WeaponAim.hpp"
@@ -66,8 +71,6 @@
 #include "Natives/NativeFunctions.hpp"
 #include "Natives/NativeHelpers.hpp"
 #include "Natives/NativeState.hpp"
-
-
 
 // ============================================================================
 // ORIENTATION-PROVIDER GetOrientation VMT INSTRUMENT (the user's "stand at the register" plan).
@@ -659,6 +662,144 @@ void SetVRMuzzleQuat(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*,
         g_pSharedHands[27] = 1.0f;  // valid
     }
 }
+
+// Publish CET's muzzle raycast result without performing a game-world query from Present. The
+// sequence brackets four independent float stores so the render thread only consumes one update.
+void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t) {
+    float x = 0.0f, y = 0.0f, z = 0.0f;
+    int32_t valid = 0;
+    RED4ext::GetParameter(aFrame, &x);
+    RED4ext::GetParameter(aFrame, &y);
+    RED4ext::GetParameter(aFrame, &z);
+    RED4ext::GetParameter(aFrame, &valid);
+    aFrame->code++;
+    EnsureSharedMemory();
+    if (!g_pSharedHands) return;
+
+    // Float retains exact integer values in this range. Bounding the counter keeps long sessions
+    // away from the 24-bit precision limit used by the shared-memory transport.
+    static uint32_t s_evenSeq = 0;
+    uint32_t nextEven = s_evenSeq + 2u;
+    if (nextEven >= 1000000u) nextEven = 2u;
+    g_pSharedHands[vrshared::kBarrelRaySeq] = static_cast<float>(nextEven - 1u);
+    std::atomic_thread_fence(std::memory_order_release);
+    g_pSharedHands[vrshared::kBarrelRayHitX + 0] = x;
+    g_pSharedHands[vrshared::kBarrelRayHitX + 1] = y;
+    g_pSharedHands[vrshared::kBarrelRayHitX + 2] = z;
+    g_pSharedHands[vrshared::kBarrelRayHitValid] = valid != 0 ? 1.0f : 0.0f;
+    std::atomic_thread_fence(std::memory_order_release);
+    g_pSharedHands[vrshared::kBarrelRaySeq] = static_cast<float>(nextEven);
+    s_evenSeq = nextEven;
+}
+
+struct HitRepQueryState {
+    alignas(16) RED4ext::game::QueryResult result{};
+    int32_t status = 0;
+    bool initialized = false;
+};
+
+static bool HitRepMatchesBytes(const uint8_t* aAddress, const uint8_t* aExpected, size_t aCount) {
+    __try {
+        if (!aAddress || !aExpected) return false;
+        for (size_t i = 0; i < aCount; ++i) {
+            if (aAddress[i] != aExpected[i]) return false;
+        }
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+static void QueryHitRepSurfaceNative(RED4ext::game::HitRepresentationComponent* aComponent,
+                                     const RED4ext::Vector4* aFrom,
+                                     const RED4ext::Vector4* aTo,
+                                     HitRepQueryState* aState) {
+    if (!aComponent || !aFrom || !aTo || !aState) return;
+    __try {
+        const uintptr_t base = reinterpret_cast<uintptr_t>(GetModuleHandleW(L"Cyberpunk2077.exe"));
+        if (!base) { aState->status = -1; return; }
+        static constexpr uint8_t kQueryBytes[] = {0x48, 0x8B, 0xC4, 0x53};
+        static constexpr uint8_t kResultCtorBytes[] = {0x83, 0x61, 0x08, 0x00};
+        if (!HitRepMatchesBytes(reinterpret_cast<const uint8_t*>(base + 0x8BB428),
+                kQueryBytes, sizeof(kQueryBytes)) ||
+            !HitRepMatchesBytes(reinterpret_cast<const uint8_t*>(base + 0x8BA038),
+                kResultCtorBytes, sizeof(kResultCtorBytes))) {
+            aState->status = -3;
+            return;
+        }
+        const auto initResult = reinterpret_cast<void (*)(RED4ext::game::QueryResult*)>(base + 0x8BA038);
+        const auto query = reinterpret_cast<bool (*)(RED4ext::game::HitRepresentationComponent*,
+            const float*, const float*, RED4ext::game::QueryResult*, void*)>(
+                base + 0x8BB428);
+        initResult(&aState->result);
+        aState->initialized = true;
+        aState->status = query(aComponent, &aFrom->X, &aTo->X, &aState->result, nullptr) ? 1 : 2;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        aState->status = -2;
+    }
+}
+
+static void DestroyHitRepQuery(HitRepQueryState* aState) {
+    if (!aState || !aState->initialized) return;
+    __try {
+        const uintptr_t base = reinterpret_cast<uintptr_t>(GetModuleHandleW(L"Cyberpunk2077.exe"));
+        if (!base) return;
+        const auto destroyResult = reinterpret_cast<void (*)(RED4ext::game::QueryResult*)>(base + 0x8B9F40);
+        destroyResult(&aState->result);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+    }
+}
+
+// Return the closest official animated HitRepresentation surface on one candidate NPC. W<=0 is a
+// miss; W=1 is a current-frame hit. Candidate selection remains script-side, while this function
+// only intersects the exact same muzzle ray with the entity's live shapes.
+void QueryVRNpcHitSurface(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame,
+                          RED4ext::Vector4* aOut, int64_t) {
+    RED4ext::Handle<RED4ext::IScriptable> entityHandle;
+    RED4ext::Vector4 from{}, to{};
+    RED4ext::GetParameter(aFrame, &entityHandle);
+    RED4ext::GetParameter(aFrame, &from);
+    RED4ext::GetParameter(aFrame, &to);
+    aFrame->code++;
+    if (!aOut) return;
+    aOut->X = 0.0f;
+    aOut->Y = 0.0f;
+    aOut->Z = 0.0f;
+    aOut->W = 0.0f;
+
+    auto* entity = reinterpret_cast<RED4ext::ent::Entity*>(entityHandle.instance);
+    if (!entity) return;
+
+    float bestDistanceSq = std::numeric_limits<float>::infinity();
+    for (auto& componentHandle : entity->components) {
+        auto* component = componentHandle.instance;
+        if (!component) continue;
+        auto* type = component->GetType();
+        if (!type || type->name != "gameHitRepresentationComponent") continue;
+
+        auto* hitRep = reinterpret_cast<RED4ext::game::HitRepresentationComponent*>(component);
+        HitRepQueryState queryState{};
+        QueryHitRepSurfaceNative(hitRep, &from, &to, &queryState);
+        if (queryState.status == 1) {
+            for (const auto& hit : queryState.result.hitShapes) {
+                const float distanceSq = hit.result.enterDistanceFromOriginSq;
+                const auto& position = hit.result.hitPositionEnter;
+                if (!std::isfinite(distanceSq) || distanceSq < 0.0f ||
+                    !std::isfinite(position.X) || !std::isfinite(position.Y) ||
+                    !std::isfinite(position.Z) || distanceSq >= bestDistanceSq) {
+                    continue;
+                }
+                bestDistanceSq = distanceSq;
+                aOut->X = position.X;
+                aOut->Y = position.Y;
+                aOut->Z = position.Z;
+                aOut->W = 1.0f;
+            }
+        }
+        DestroyHitRepQuery(&queryState);
+    }
+}
+
 // Publish the current ADS/scope zoom factor to shared[28] so the dxgi overlay can scale the
 // barrel laser-dot's screen offset by it (the scope magnifies the image but the bullet still
 // leaves the barrel). CET pushes PlayerStateMachine.ZoomLevel each frame; 1.0 = no zoom.
@@ -894,5 +1035,4 @@ void ResetVRProvCounts(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void
     g_provOverrides = 0;
     for (int i = 0; i < 4; ++i) { g_provLastQ[i]=0; g_provOrigQ[i]=0; g_provCtrlQ[i]=0; g_provHmdQ[i]=0; }
 }
-
 

--- a/src/Natives/Registration.cpp
+++ b/src/Natives/Registration.cpp
@@ -714,6 +714,8 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes() {
     fBarrelRay->AddParam("Float", "y");
     fBarrelRay->AddParam("Float", "z");
     fBarrelRay->AddParam("Int32", "valid");
+    fBarrelRay->AddParam("Int32", "mainVisible");
+    fBarrelRay->AddParam("Int32", "secondVisible");
     rtti->RegisterFunction(fBarrelRay);
     auto fNpcSurface = RED4ext::CGlobalFunction::Create(
         "QueryVRNpcHitSurface", "QueryVRNpcHitSurface", &QueryVRNpcHitSurface);

--- a/src/Natives/Registration.cpp
+++ b/src/Natives/Registration.cpp
@@ -707,6 +707,22 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes() {
     fProvReset->flags = flags; rtti->RegisterFunction(fProvReset);
     auto fProvQM = RED4ext::CGlobalFunction::Create("SetVRProvQuatMode", "SetVRProvQuatMode", &SetVRProvQuatMode);
     fProvQM->flags = flags; fProvQM->AddParam("Int32", "mode"); fProvQM->AddParam("Int32", "axis"); rtti->RegisterFunction(fProvQM);
+    auto fBarrelRay = RED4ext::CGlobalFunction::Create(
+        "SetVRBarrelRayHit", "SetVRBarrelRayHit", &SetVRBarrelRayHit);
+    fBarrelRay->flags = flags;
+    fBarrelRay->AddParam("Float", "x");
+    fBarrelRay->AddParam("Float", "y");
+    fBarrelRay->AddParam("Float", "z");
+    fBarrelRay->AddParam("Int32", "valid");
+    rtti->RegisterFunction(fBarrelRay);
+    auto fNpcSurface = RED4ext::CGlobalFunction::Create(
+        "QueryVRNpcHitSurface", "QueryVRNpcHitSurface", &QueryVRNpcHitSurface);
+    fNpcSurface->flags = flags;
+    fNpcSurface->AddParam("handle:GameObject", "entity");
+    fNpcSurface->AddParam("Vector4", "from");
+    fNpcSurface->AddParam("Vector4", "to");
+    fNpcSurface->SetReturnType("Vector4");
+    rtti->RegisterFunction(fNpcSurface);
     auto fMuzP = RED4ext::CGlobalFunction::Create("SetVRMuzzlePos", "SetVRMuzzlePos", &SetVRMuzzlePos);
     fMuzP->flags = flags;
     fMuzP->AddParam("Float", "x"); fMuzP->AddParam("Float", "y"); fMuzP->AddParam("Float", "z");
@@ -924,4 +940,3 @@ void CyberpunkVR_RegisterHandsNatives() {
     rtti->AddRegisterCallback(RegisterTypes);
     rtti->AddPostRegisterCallback(PostRegisterTypes);
 }
-

--- a/src/Overlay/OverlayDebugDraw.cpp
+++ b/src/Overlay/OverlayDebugDraw.cpp
@@ -315,6 +315,7 @@ extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 2;
 extern "C" int CyberpunkVR_MainIsRightEye;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_BarrelDotTick = 0;
 extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondEye = 1;
+extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondVisible = 1;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_DebugBarrelDotDraws = 0;
 
 // EXACT barrel crosshair. The plugin publishes the weapon muzzle WORLD forward (shared[24..26]); we
@@ -374,10 +375,20 @@ void DrawCompactAdsCameraTelemetry() {
 void DrawBarrelCrosshair() {
     
     const float enableLaser = OpenXRManager::Get().GetSharedSlot(144);   // weapon flag (was [126]: HMD-Z collision)
+    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
+    const bool raycastActive = g_drawBarrelCross && surfaceMode && enableLaser >= 0.9f;
+    // CET owns every physics query. Publish the UI/mode gate before returning so disabling a dot
+    // stops muzzle and visibility work rather than merely stopping the final draw.
+    OpenXRManager::Get().SetSharedSlot(vrshared::kBarrelRayActive, raycastActive ? 1.0f : 0.0f);
     
     float rad = 3.0f;
     
     if (!g_drawBarrelCross || enableLaser < 0.9f){
+        // The second eye is stamped by the capture path rather than ImGui. Clear its publication
+        // immediately when the common UI/weapon gate closes instead of waiting for the 250 ms
+        // consumer safety timeout.
+        CyberpunkVR_BarrelDotTick = 0;
+        CyberpunkVR_BarrelDotSecondVisible = 0;
         /*rad = 0.0f;
         // Background list: world-projected, see DrawHandLocatorOverlay.
         ImDrawList* dl = ImGui::GetBackgroundDrawList();
@@ -438,12 +449,12 @@ void DrawBarrelCrosshair() {
     const bool haveWorld = (mpx * mpx + mpy * mpy + mpz * mpz) > 1.0f &&
                            (hcx * hcx + hcy * hcy + hcz * hcz) > 1.0f;
 
-    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
     // CET owns the physics query and publishes one world-space hit packet. A sequence that stops
     // changing means the publisher was interrupted; never leave the last dot glued to a wall.
     static uint32_t s_lastRaySeq = 0;
     static uint64_t s_lastRayTick = 0;
     float hitx = 0.0f, hity = 0.0f, hitz = 0.0f, hitValid = 0.0f;
+    float mainVisible = 1.0f, secondVisible = 1.0f;
     uint32_t raySeq = 0;
     bool rayPacket = false;
     for (int attempt = 0; surfaceMode && attempt < 3 && !rayPacket; ++attempt) {
@@ -455,11 +466,15 @@ void DrawBarrelCrosshair() {
         const float y = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 1);
         const float z = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 2);
         const float v = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitValid);
+        const float vm = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelMainVisible);
+        const float vs = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelSecondVisible);
         std::atomic_thread_fence(std::memory_order_acquire);
         const uint32_t s1 = static_cast<uint32_t>(
             OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRaySeq));
         if (s0 == s1 && !(s1 & 1u)) {
-            hitx = x; hity = y; hitz = z; hitValid = v; raySeq = s1; rayPacket = true;
+            hitx = x; hity = y; hitz = z; hitValid = v;
+            mainVisible = vm; secondVisible = vs;
+            raySeq = s1; rayPacket = true;
         }
     }
     if (rayPacket && raySeq != s_lastRaySeq) {
@@ -486,6 +501,36 @@ void DrawBarrelCrosshair() {
     float halfIpd = CyberpunkVRPort_HalfIpd();
     if (!(halfIpd > 0.0001f)) halfIpd = OpenXRManager::Get().GetSharedSlot(95);
     if (!(halfIpd > 0.0001f)) halfIpd = 0.0325f;
+
+    // Publish exactly the two synthetic eye origins used by the dot projection. Naming these
+    // MAIN/second avoids assuming which physical eye MAIN owns when the live eye sign is flipped.
+    // CET reads the pair through this seqlock before issuing its game-thread visibility rays.
+    const float sMain = (CyberpunkVR_BarrelDotEyeSign >= 0) ? +1.0f : -1.0f;
+    const float mainEye[3] = {
+        hcx + rgt[0] * halfIpd * sMain,
+        hcy + rgt[1] * halfIpd * sMain,
+        hcz + rgt[2] * halfIpd * sMain
+    };
+    const float secondEye[3] = {
+        hcx - rgt[0] * halfIpd * sMain,
+        hcy - rgt[1] * halfIpd * sMain,
+        hcz - rgt[2] * halfIpd * sMain
+    };
+    {
+        static uint32_t s_eyeSeq = 0;
+        uint32_t nextEven = s_eyeSeq + 2u;
+        if (nextEven >= 1000000u) nextEven = 2u;
+        auto& xr = OpenXRManager::Get();
+        xr.SetSharedSlot(vrshared::kBarrelEyeSeq, static_cast<float>(nextEven - 1u));
+        std::atomic_thread_fence(std::memory_order_release);
+        for (int i = 0; i < 3; ++i) {
+            xr.SetSharedSlot(vrshared::kBarrelMainEyeX + i, mainEye[i]);
+            xr.SetSharedSlot(vrshared::kBarrelSecondEyeX + i, secondEye[i]);
+        }
+        std::atomic_thread_fence(std::memory_order_release);
+        xr.SetSharedSlot(vrshared::kBarrelEyeSeq, static_cast<float>(nextEven));
+        s_eyeSeq = nextEven;
+    }
 
     // Screen position of the impact point as seen from one eye. sign: -1 = MAIN/left, +1 = VRCAM.
     static float s_dbgLy[2] = {0.0f, 0.0f};
@@ -529,7 +574,6 @@ void DrawBarrelCrosshair() {
     // Sign fixed by observation: a fixed world point must slide LEFT on screen when the eye
     // moves RIGHT, and it was doing the opposite -- the second eye sat right of the first. So
     // MAIN is the +right eye here, not the -right one. Live switch rather than a silent constant.
-    const float sMain = (CyberpunkVR_BarrelDotEyeSign >= 0) ? +1.0f : -1.0f;
     // Do NOT require both, and do NOT fall back. Requiring both meant one failed projection
     // dropped the pair onto the direction path, which is wrong for the second eye BY
     // CONSTRUCTION -- a mark at infinity cannot show a finite impact from an eye off the line.
@@ -595,10 +639,13 @@ void DrawBarrelCrosshair() {
         }
         CyberpunkVR_BarrelDotRadiusPx = rad;
         CyberpunkVR_BarrelDotTick = GetTickCount64();
+        const bool mainDotVisible = !surfaceMode || !rayFresh || mainVisible > 0.5f;
+        CyberpunkVR_BarrelDotSecondVisible =
+            (!surfaceMode || !rayFresh || secondVisible > 0.5f) ? 1 : 0;
 
         // Background list: world-projected, see DrawHandLocatorOverlay.
         ImDrawList* dl = ImGui::GetBackgroundDrawList();
-        if (dl) {
+        if (dl && mainDotVisible) {
             dl->AddCircleFilled(sc, rad, IM_COL32(255, 60, 60, 255));
             //dl->AddCircle(sc, 11.0f, IM_COL32(255, 255, 255, 235), 0, 2.0f);
         }

--- a/src/Overlay/OverlayDebugDraw.cpp
+++ b/src/Overlay/OverlayDebugDraw.cpp
@@ -10,6 +10,7 @@
 
 #include "Overlay/ImGuiOverlay.hpp"
 #include "Overlay/LiveControlsUi.hpp"
+#include "Core/LiveControls.hpp"
 #include "Runtimes/OpenXRManager.hpp"
 #include <algorithm>
 #include <atomic>
@@ -311,7 +312,7 @@ extern "C" __declspec(dllexport) float    CyberpunkVR_BarrelDotOffX2 = 0.0f;
 // 0 = one projection for both eyes plus a constant parallax on the second (simple, steady).
 // 1 = a real world point projected per eye (exact, but only as steady as the muzzle transform).
 // 2 = the closest raycast surface projected per eye; a miss uses mode 0.
-extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 2;
+extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 1;
 extern "C" int CyberpunkVR_MainIsRightEye;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_BarrelDotTick = 0;
 extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondEye = 1;
@@ -373,9 +374,12 @@ void DrawCompactAdsCameraTelemetry() {
 }
 
 void DrawBarrelCrosshair() {
-    
+    int laserDotMode = g_liveControls.xrLaserDotMode;
+    if (laserDotMode < 0 || laserDotMode > 2) laserDotMode = 1;
+    CyberpunkVR_BarrelDotWorld = laserDotMode;
+
     const float enableLaser = OpenXRManager::Get().GetSharedSlot(144);   // weapon flag (was [126]: HMD-Z collision)
-    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
+    const bool surfaceMode = laserDotMode == 2;
     const bool raycastActive = g_drawBarrelCross && surfaceMode && enableLaser >= 0.9f;
     // CET owns every physics query. Publish the UI/mode gate before returning so disabling a dot
     // stops muzzle and visibility work rather than merely stopping the final draw.

--- a/src/Overlay/OverlayDebugDraw.cpp
+++ b/src/Overlay/OverlayDebugDraw.cpp
@@ -12,6 +12,7 @@
 #include "Overlay/LiveControlsUi.hpp"
 #include "Runtimes/OpenXRManager.hpp"
 #include <algorithm>
+#include <atomic>
 #include <cfloat>
 #include <cmath>
 #include <cstdio>
@@ -22,6 +23,7 @@
 #include <imgui_impl_win32.h>
 #include "im3d.h"
 #include "Camera/CameraLink.hpp"   // cvr::camera::BarrelFrameRead
+#include "Utils/SharedSlots.hpp"
 #include "Overlay/OverlayInternal.hpp"
 
 extern volatile int g_verboseLog; // per-frame log spam toggle (default off)
@@ -308,7 +310,8 @@ extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotEyeSign = 1;
 extern "C" __declspec(dllexport) float    CyberpunkVR_BarrelDotOffX2 = 0.0f;
 // 0 = one projection for both eyes plus a constant parallax on the second (simple, steady).
 // 1 = a real world point projected per eye (exact, but only as steady as the muzzle transform).
-extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 1;
+// 2 = the closest raycast surface projected per eye; a miss uses mode 0.
+extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 2;
 extern "C" int CyberpunkVR_MainIsRightEye;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_BarrelDotTick = 0;
 extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondEye = 1;
@@ -435,6 +438,40 @@ void DrawBarrelCrosshair() {
     const bool haveWorld = (mpx * mpx + mpy * mpy + mpz * mpz) > 1.0f &&
                            (hcx * hcx + hcy * hcy + hcz * hcz) > 1.0f;
 
+    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
+    // CET owns the physics query and publishes one world-space hit packet. A sequence that stops
+    // changing means the publisher was interrupted; never leave the last dot glued to a wall.
+    static uint32_t s_lastRaySeq = 0;
+    static uint64_t s_lastRayTick = 0;
+    float hitx = 0.0f, hity = 0.0f, hitz = 0.0f, hitValid = 0.0f;
+    uint32_t raySeq = 0;
+    bool rayPacket = false;
+    for (int attempt = 0; surfaceMode && attempt < 3 && !rayPacket; ++attempt) {
+        const uint32_t s0 = static_cast<uint32_t>(
+            OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRaySeq));
+        if (s0 == 0u || (s0 & 1u)) continue;
+        std::atomic_thread_fence(std::memory_order_acquire);
+        const float x = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 0);
+        const float y = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 1);
+        const float z = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 2);
+        const float v = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitValid);
+        std::atomic_thread_fence(std::memory_order_acquire);
+        const uint32_t s1 = static_cast<uint32_t>(
+            OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRaySeq));
+        if (s0 == s1 && !(s1 & 1u)) {
+            hitx = x; hity = y; hitz = z; hitValid = v; raySeq = s1; rayPacket = true;
+        }
+    }
+    if (rayPacket && raySeq != s_lastRaySeq) {
+        s_lastRaySeq = raySeq;
+        s_lastRayTick = GetTickCount64();
+    }
+    const uint64_t nowTick = GetTickCount64();
+    const bool rayFresh = rayPacket && s_lastRayTick != 0 && (nowTick - s_lastRayTick) <= 20u;
+    const bool haveRayHit = surfaceMode && rayFresh && hitValid > 0.5f &&
+                            (hcx * hcx + hcy * hcy + hcz * hcz) > 1.0f &&
+                            (hitx * hitx + hity * hity + hitz * hitz) > 1.0f;
+
     const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
     if (displaySize.x <= 1.0f || displaySize.y <= 1.0f) return;
 
@@ -471,6 +508,16 @@ void DrawBarrelCrosshair() {
         if (!okp) s_dbgWhy = 3.0f;
         return okp;
     };
+    auto surfaceDotForEye = [&](float sign, ImVec2* out) -> bool {
+        if (!haveRayHit) return false;
+        const float ex = hcx + rgt[0] * halfIpd * sign;
+        const float ey = hcy + rgt[1] * halfIpd * sign;
+        const float ez = hcz + rgt[2] * halfIpd * sign;
+        float lx = 0.0f, ly = 0.0f, lz = 0.0f;
+        RotateVectorByQuaternion(hitx - ex, hity - ey, hitz - ez,
+                                 -cqx, -cqy, -cqz, cqw, &lx, &ly, &lz);
+        return ProjectHeadSpacePointToScreen(lx, lz, -ly, displaySize, out);
+    };
 
     ImVec2 sc{};
     // game-cam-local (Yfwd/Xright/Zup) -> OpenXR view convention (forward -Z, right +X, up +Y): (x, z, -y)
@@ -487,13 +534,13 @@ void DrawBarrelCrosshair() {
     // dropped the pair onto the direction path, which is wrong for the second eye BY
     // CONSTRUCTION -- a mark at infinity cannot show a finite impact from an eye off the line.
     // That is what made the right eye's dot sit right of the shot on half the frames.
-    const bool mainOk = dotForEye(sMain, &sc);
-    if (!dotForEye(-sMain, &scRight)) scRight = sc;
+    const bool mainOk = surfaceMode ? surfaceDotForEye(sMain, &sc) : dotForEye(sMain, &sc);
+    if (!(surfaceMode ? surfaceDotForEye(-sMain, &scRight) : dotForEye(-sMain, &scRight))) scRight = sc;
     // OFF by default. The world point is the exact answer, but it depends on a muzzle transform
     // that goes to identity between frames (fists, and recoil right after a shot) -- latched, it
     // then lags and the two dots visibly part company. The simple form below has none of that:
     // one projection, plus a constant parallax for the second eye.
-    const bool worldOk = mainOk && (CyberpunkVR_BarrelDotWorld != 0);
+    const bool worldOk = mainOk && (surfaceMode ? haveRayHit : CyberpunkVR_BarrelDotWorld != 0);
     {
         static int s_said = -1;
         const int now = worldOk ? 1 : 0;
@@ -508,7 +555,7 @@ void DrawBarrelCrosshair() {
         }
     }
     // With world data present the direction path is not a fallback, it is a wrong answer.
-    if (CyberpunkVR_BarrelDotWorld && haveWorld && !worldOk) return;
+    if (CyberpunkVR_BarrelDotWorld == 1 && haveWorld && !worldOk) return;
     if (worldOk || ProjectHeadSpacePointToScreen(vx, vz, -vy, displaySize, &sc)) {
         // NO ZOOM COMPENSATION HERE ANY MORE (dabinn, TofuExpress 2cb7b031). ADS magnification is
         // already in the projection this point was built with -- GetOverlayProjTans divides the
@@ -543,7 +590,7 @@ void DrawBarrelCrosshair() {
             }
             CyberpunkVR_BarrelDotNdcX2 = (worldOk
                 ? ((scRight.x / displaySize.x) * 2.0f - 1.0f)   // its own eye, its own ray
-                : (CyberpunkVR_BarrelDotNdcX + dx))
+                : (CyberpunkVR_BarrelDotNdcX + (surfaceMode ? 0.0f : dx)))
                 + CyberpunkVR_BarrelDotOffX2;
         }
         CyberpunkVR_BarrelDotRadiusPx = rad;

--- a/src/Overlay/OverlayPanels.cpp
+++ b/src/Overlay/OverlayPanels.cpp
@@ -695,10 +695,33 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                                       "the weapon arm. Either way the shot leaves the real muzzle, for guns and\n"
                                       "projectiles alike, and free-look while aiming is preserved.");
                 }
-                ImGui::Checkbox("Weapon Aim laser dot (where the bullet hits)", &g_drawBarrelCross);
+                ImGui::Checkbox("Laser dot", &g_drawBarrelCross);
                 if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip("Red dot projected from the actual weapon muzzle direction through the\n"
-                                      "game camera -- marks exactly where the bullet will fly.");
+                    ImGui::SetTooltip("Show a red aiming dot projected from the weapon muzzle.\n"
+                                      "Select how its depth is determined with the mode selector.");
+                }
+                ImGui::SameLine();
+                ImGui::SetNextItemWidth(190.0f);
+                static const char* kLaserDotModes[] = {
+                    "Steady projection",
+                    "Real world point",
+                    "Surface raycast"
+                };
+                int laserDotMode = state.xrLaserDotMode;
+                if (laserDotMode < 0 || laserDotMode > 2) laserDotMode = 1;
+                if (ImGui::Combo("##laserDotMode", &laserDotMode, kLaserDotModes,
+                                 IM_ARRAYSIZE(kLaserDotModes))) {
+                    state.xrLaserDotMode = laserDotMode;
+                    changed = true;
+                }
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip(
+                        "Steady projection\n"
+                        "Simple and steady stereo projection.\n\n"
+                        "Real world point\n"
+                        "Places the dot at a real point in 3D space ahead of the weapon.\n\n"
+                        "Surface raycast\n"
+                        "Places the dot on the surface hit by the weapon's pointing ray.");
                 }
             }
             ImGui::Separator();

--- a/src/Runtimes/OpenXRCapture.cpp
+++ b/src/Runtimes/OpenXRCapture.cpp
@@ -49,6 +49,7 @@ extern "C" float    CyberpunkVR_BarrelDotNdcY;
 extern "C" float    CyberpunkVR_BarrelDotRadiusPx;
 extern "C" unsigned long long CyberpunkVR_BarrelDotTick;
 extern "C" int      CyberpunkVR_BarrelDotSecondEye;
+extern "C" int      CyberpunkVR_BarrelDotSecondVisible;
 extern "C" unsigned long long CyberpunkVR_DebugBarrelDotDraws;
 extern "C" ID3D12Resource* CyberpunkVR_GetHudBlurTexture();
 extern "C" ID3D12Resource* CyberpunkVR_GetHudExposureBuffer();
@@ -966,6 +967,7 @@ bool OpenXRManager::CaptureMonoPresentedFrame(ID3D12Resource* backBuffer, const 
                     // dot in BOTH eyes the question stops being "does the right eye's reticle
                     // match the left eye's dot", which no one can judge across a fused pair.
                     if (vrcamEyeCaptured && CyberpunkVR_BarrelDotSecondEye &&
+                        CyberpunkVR_BarrelDotSecondVisible &&
                         CyberpunkVR_BarrelDotTick &&
                         GetTickCount64() - CyberpunkVR_BarrelDotTick < 250) {
                         if (m_colorBlit->RecordDot(m_captureCmdList, eyeSlotTex,

--- a/src/Stereo/Mirror.cpp
+++ b/src/Stereo/Mirror.cpp
@@ -220,7 +220,8 @@ void d12_submit_mirror_copy(ID3D12CommandQueue* queue) {
         // The barrel dot, at the same NDC the overlay drew it at on the backbuffer. The mirror
         // window IS the desk-side view of eye 1, so without this the dot is invisible whenever
         // there is no headset session -- which is most of the time while working on it.
-        if (hud_composited && CyberpunkVR_BarrelDotSecondEye && CyberpunkVR_BarrelDotTick &&
+        if (hud_composited && CyberpunkVR_BarrelDotSecondEye &&
+            CyberpunkVR_BarrelDotSecondVisible && CyberpunkVR_BarrelDotTick &&
             GetTickCount64() - CyberpunkVR_BarrelDotTick < 250) {
             if (g_hud_mirror_blit.RecordDot(g_d12_copy_list, g_d12_mtex,
                                             CyberpunkVR_BarrelDotNdcX2,


### PR DESCRIPTION
This PR adds the raycast-based laser dot described and tested in #59.

The work is split into three commits so each part can be reviewed or picked independently:

1. **Surface raycast**

   * Projects the laser dot onto the actual surface hit by a ray from the weapon muzzle.
   * Falls back to **Steady projection** when no surface is hit.

2. **Per-eye occlusion**

   * Handles cases where the muzzle can see the target surface but the player's eye cannot, such as aiming past the edge of a nearby object.
   * Hides the dot when the surface it lands on is blocked from that eye's view.
   * Checks each eye independently for correct stereo behavior.
   * Visibility rays pass through glass while still detecting blockers behind it.

3. **Laser dot modes**

   * Adds three selectable modes to the F10 overlay:

     * **Steady projection** — Simple and steady stereo projection.
     * **Real world point** — Places the dot at a real point in 3D space ahead of the weapon.
     * **Surface raycast** — Places the dot on the surface hit by the weapon's pointing ray.
   * Keeps **Real world point** as the default, matching the current upstream behavior.
   * Saves the selected mode in the config.

More details and the demo video are in #59.
