### PR TITLE
Fix Physical Body Rotation VR base synchronization

### DIFF
--- a/include/Camera/CameraState.hpp
+++ b/include/Camera/CameraState.hpp
@@ -138,6 +138,10 @@ extern "C" __declspec(dllexport) extern int      CyberpunkVR_VrikArmAnchorFromBo
 extern "C" __declspec(dllexport) extern int      CyberpunkVR_VrikElbowPolicy;
 extern "C" __declspec(dllexport) extern int      CyberpunkVR_BodyYawFollow;
 extern "C" __declspec(dllexport) extern float    CyberpunkVR_BodyYawRealignRad;
+extern "C" float BodyYawBridgeCurrentRealignRad();
+extern "C" float BodyYawBridgeRealignForEpoch(uint64_t epoch);
+extern "C" void BodyYawBridgeAcknowledgeRenderedCamera(uint64_t epoch, float bridgeUsed);
+extern "C" bool BodyYawBridgeNeedsProtection();
 extern "C" __declspec(dllexport) extern float    CyberpunkVR_BodyYawFollowDeadDeg;
 extern "C" __declspec(dllexport) extern float    CyberpunkVR_DebugBodyFollowOffsetDeg;
 extern "C" __declspec(dllexport) extern float    CyberpunkVR_DebugBodyFollowErrDeg;

--- a/include/Runtimes/OpenXRManager.hpp
+++ b/include/Runtimes/OpenXRManager.hpp
@@ -27,6 +27,11 @@ struct OpenXRHeadPose {
     float oriZ;
     float oriW;
     bool valid;
+    // The exact recenter base used to derive this relative pose. Render/read-back queues carry
+    // this snapshot with the pose so Present never reconstructs an old frame with a newer base.
+    XrPosef recenterBase{};
+    uint64_t frameAimEpoch = 0;
+    bool recenterBaseValid = false;
 };
 
 // Aggregated VR-controller snapshot, queried each frame from the XInput hook
@@ -117,6 +122,9 @@ public:
     // must not read the cached atomics above.
     bool LocateHeadPoseAt(XrTime displayTime, OpenXRHeadPose* out);
     void RequestRecenter();
+    bool IsRuntimeLocalRecenterPending() const {
+        return m_runtimeLocalRecenterPending.load(std::memory_order_acquire);
+    }
     void OnPresent(IDXGISwapChain* swapChain);
     // Run one XR frame inline on the Present thread instead of a dedicated
     // frame thread.
@@ -236,6 +244,11 @@ public:
     // moment the user recenters facing anywhere else.
     void GetRecenterBase(XrPosef* out) const {
         if (!out) return;
+        std::lock_guard<std::mutex> lock(m_renderPoseMutex);
+        if (m_basePoseSet) {
+            *out = m_basePose;
+            return;
+        }
         out->orientation.x = m_baseOriX.load(std::memory_order_relaxed);
         out->orientation.y = m_baseOriY.load(std::memory_order_relaxed);
         out->orientation.z = m_baseOriZ.load(std::memory_order_relaxed);
@@ -442,6 +455,7 @@ public:
         m_frameAimStampUs.store(XrDiagNowUs(), std::memory_order_release);
         m_frameAimEpoch.fetch_add(1, std::memory_order_acq_rel);
     }
+    bool BeginFrameAimEpochWithBaseFold(XrTime t, float foldYaw);
     XrTime   GetFrameAimTime() const { return m_frameAimTime.load(std::memory_order_acquire); }
 
     // THE AIM TIME, CARRIED FORWARD TO NOW -- and it exists because the plain aim time is the wrong
@@ -499,29 +513,37 @@ public:
     // callers return the stored one.
     bool AcquireFrameHeadSample(OpenXRHeadPose* out) {
         if (!out) return false;
-        const uint64_t epoch = m_frameAimEpoch.load(std::memory_order_acquire);
-        {
-            std::lock_guard<std::mutex> lock(m_frameSampleMutex);
-            if (m_frameSampleEpoch == epoch && m_frameSample.valid) {
+        for (int attempt = 0; attempt < 3; ++attempt) {
+            uint64_t epoch = 0;
+            {
+                std::lock_guard<std::mutex> lock(m_frameSampleMutex);
+                epoch = m_frameAimEpoch.load(std::memory_order_acquire);
+                if (m_frameSampleEpoch == epoch && m_frameSample.valid) {
+                    *out = m_frameSample;
+                    return true;
+                }
+            }
+            OpenXRHeadPose p{};
+            bool ok = false;
+            const XrTime aim = m_frameAimTime.load(std::memory_order_acquire);
+            if (aim > 0) ok = LocateHeadPoseAt(aim, &p) && p.valid;
+            if (!ok) ok = GetHeadPose(&p) && p.valid;   // pre-session / locate failure
+            if (!ok) return false;
+            p.frameAimEpoch = epoch;
+            {
+                std::lock_guard<std::mutex> lock(m_frameSampleMutex);
+                if (m_frameAimEpoch.load(std::memory_order_acquire) != epoch) {
+                    continue;
+                }
+                if (m_frameSampleEpoch != epoch || !m_frameSample.valid) {
+                    m_frameSample = p;
+                    m_frameSampleEpoch = epoch;
+                }
                 *out = m_frameSample;
-                return true;
             }
+            return out->valid;
         }
-        OpenXRHeadPose p{};
-        bool ok = false;
-        const XrTime aim = m_frameAimTime.load(std::memory_order_acquire);
-        if (aim > 0) ok = LocateHeadPoseAt(aim, &p) && p.valid;
-        if (!ok) ok = GetHeadPose(&p) && p.valid;   // pre-session / locate failure
-        if (!ok) return false;
-        {
-            std::lock_guard<std::mutex> lock(m_frameSampleMutex);
-            if (m_frameSampleEpoch != epoch || !m_frameSample.valid) {
-                m_frameSample = p;
-                m_frameSampleEpoch = epoch;
-            }
-            *out = m_frameSample;
-        }
-        return out->valid;
+        return false;
     }
 
     // ---- THE POSE THAT IS ACTUALLY IN THE FRAME, READ BACK FROM THE ENGINE -------------------
@@ -771,13 +793,6 @@ public:
     // locomotion (character walks the way the chosen controller points). Returns
     // 0 if the controller pose isn't valid this frame.
     float GetHandYawRelToBody(int side) const;
-
-    // Body-realign support: rotate the recenter base about the vertical axis by
-    // `radians`, IN STEP with an equal heading injection (dxgi OnOnFootDeltaHead).
-    // relOri/relPos are conj(base)*head, so base*Ry(a) shifts the HMD's relative yaw
-    // by -a while the reconstructed raw pose (base*rel) is unchanged: the rendered
-    // view and the HMD-local hand poses stay put while the body turns underneath.
-    void RotateBaseYaw(float radians);
 
     // Physical-body yaw estimate (radians, rel recenter base, same convention as
     // GetHmdYawRelToBody) from the CONTROLLER POSITIONS: the left->right hand line
@@ -1234,6 +1249,10 @@ private:
     std::atomic<float> m_linVelY = 0.0f;
     std::atomic<float> m_linVelZ = 0.0f;
     std::atomic<bool> m_recenterRequested = false;
+    // A native runtime recenter changes LOCAL coordinates at changeTime. Body follow must not
+    // consume a head pose from the new LOCAL space while m_basePose still belongs to the old one.
+    std::atomic<XrTime> m_runtimeLocalRecenterChangeTime{0};
+    std::atomic<bool> m_runtimeLocalRecenterPending{false};
     std::atomic<bool> m_syncedPoseValid = false;
     std::atomic<float> m_syncedPosX = 0.0f;
     std::atomic<float> m_syncedPosY = 0.0f;
@@ -1246,7 +1265,11 @@ private:
     XrFovf m_syncedEyeFovs[2]{};
     bool m_syncedEyeViewsValid = false;
     // Per-eye head pose captured at render time by the camera hook (render-pose submit).
-    std::mutex m_renderPoseMutex;
+    mutable std::mutex m_renderPoseMutex;
+    mutable std::mutex m_cachedHeadPoseMutex;
+    XrPosef m_cachedHeadBase{};
+    uint64_t m_cachedHeadBaseGeneration = 0;
+    uint64_t m_cachedHeadFrameAimEpoch = 0;
     // The pose the camera injection actually used for the frame being built (see
     // SetPendingRenderHeadPose). Present attaches this to the snapshot it captures.
     std::mutex m_pendingRenderPoseMutex;
@@ -1264,6 +1287,7 @@ private:
     
     bool m_basePoseSet = false;
     XrPosef m_basePose{};
+    uint64_t m_basePoseGeneration = 0;
 
     // MENU PANEL ANCHOR (LAZY-FOLLOW). The menu/map panel is anchored in front of the
     // player when a menu opens and then holds still while the head turns WITHIN a

--- a/src/Anim/CharacterRig.cpp
+++ b/src/Anim/CharacterRig.cpp
@@ -1443,7 +1443,8 @@ bool VRIK_ComputeCamModel(float* outPos, float* outRot, float* outEntityQuat,
                         VRIK_QuatNorm(currentEntQ);
                         float invCurrentEnt[4]; VRIK_QuatConj(currentEntQ, invCurrentEnt);
 
-                        float viewYaw = 2.0f * std::atan2(wz, ww) - CyberpunkVR_BodyYawRealignRad;
+                        const float bridge = BodyYawBridgeRealignForEpoch(head.frameAimEpoch);
+                        float viewYaw = 2.0f * std::atan2(wz, ww) - bridge;
                         const float yawQ[4] = { 0.0f, 0.0f,
                                                 std::sin(viewYaw * 0.5f),
                                                 std::cos(viewYaw * 0.5f) };

--- a/src/Hooks/BodyYawFollow.cpp
+++ b/src/Hooks/BodyYawFollow.cpp
@@ -35,30 +35,23 @@
 //      them -- and whether the engine recomputes it after our write -- is a race with its own pass
 //      order, not an invariant. It remains the right route for a PURELY VISUAL body turn.
 //
-// WHERE THE CANCELLATION LIVES, AND WHY NOT IN THE RECENTER BASE. The heading also feeds the camera,
-// so injecting into it would swing the view. The old on-foot code cancelled that with
-// RotateBaseYaw(step): the frame loop reports the head relative to that base both ways --
+// WHERE THE CANCELLATION LIVES. The heading also feeds the camera, so injecting into it would swing
+// the view. The frame loop reports the head relative to the recenter base both ways --
 //     relPos = RotateVector(conj(base.ori), headPos - base.pos)
 //     relOri = conj(base.ori) * headOri
 // -- so the head's orientation and its room position each lose what the heading gained, and the view,
-// the play space and the head-local hand poses all stay put. Correct in the algebra, wrong in the
-// ORDER: the heading changes inside the game tick while the base only takes effect on the next XR
-// cycle, so for one frame the view swings by the whole step. That is the camera drift this feature
-// was always reported to have.
+// the play space and the head-local hand poses all stay put. But applying that base rotation directly
+// from the game tick is one XR epoch late: the heading has already changed while the sampled pose still
+// belongs to the old base. The temporary camera bridge cancels that in the same rendered frame:
 //
-// So the base is left alone -- recentring keeps working exactly as before -- and the cancellation is
-// done on our side, in the same frame, where the view is composed:
+//     body   yaw = E          (engine's own, ours included: E = E0 + bridge)
+//     view   yaw = E - bridge (PatchCamera and LocateCamera)
+//     solve  yaw = E          (world->model in the pose path)
 //
-//     body   yaw = E            (engine's own, ours included: E = E0 + realign)
-//     view   yaw = E - realign  (PatchCamera, LocateCamera's head-offset recipe)
-//     solve  yaw = E            (world->model in the pose path)
-//
-// The view is then exactly what it would have been had the body never turned, the play space is
-// anchored to the heading that existed at recenter, and the hands need no compensation of their own:
-// their poses are head-local against an untouched base, and the solve converting with the body's TRUE
-// yaw puts the model-space target back at the controller. That last point is also self-correcting --
-// the solve reads the yaw the engine actually ended up at (from the census), so a heading the engine
-// clamps or eases still leaves the hands on the controllers.
+// Once a rendered camera acknowledges the bridge, the next safe XR epoch folds the same yaw into the
+// recenter base and retires it from the bridge. Every rendered/submit pose carries the exact base
+// snapshot that produced it, so a fold cannot relabel an older image with the new reference frame.
+// Recenter resets both the base and any in-flight bridge debt.
 
 #include "Core/VrCoreShared.hpp"
 #include "Hooks/Hook.hpp"
@@ -71,6 +64,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cmath>
+#include <mutex>
 
 extern void Log(const char* fmt, ...);
 
@@ -159,9 +153,8 @@ bool VRIK_ReadNativeTransformSnapshot(VrikTransformSnapshot* out) {
     return false;
 }
 
-// THE ACCUMULATED REALIGN, radians, game space about +Z: how much of the engine's current heading is
-// ours rather than the player's own turning. LOAD-BEARING -- the view is composed from
-// (engine yaw - this), and if it is wrong the view drifts by the error.
+// The exported mirror of the temporary camera bridge. It no longer accumulates for the session:
+// acknowledged yaw is folded into m_basePose at the next XR epoch and retired from this value.
 extern "C" __declspec(dllexport) float CyberpunkVR_BodyYawRealignRad = 0.0f;
 
 // Readable live: the same realign in degrees, the head-against-body residual, and the two counters.
@@ -183,16 +176,123 @@ extern "C" __declspec(dllexport) int   CyberpunkVR_PlayerEntityValid = 0;
 
 namespace {
 
+struct BodyYawBridgeState {
+    float pendingGameYaw = 0.0f;
+    float readyBaseFoldYaw = 0.0f;
+    float activeCameraBridgeYaw = 0.0f;
+    float previousEpochBridgeYaw = 0.0f;
+    uint64_t currentEpoch = 0;
+    uint64_t previousEpoch = ~0ull;
+};
+
+std::mutex s_bodyYawBridgeMutex;
+BodyYawBridgeState s_bodyYawBridge{};
+std::atomic<bool> s_bodyYawBridgeHasDebt{false};
+
+float WrapYaw(float yaw) {
+    while (yaw > 3.14159265f) yaw -= 6.28318531f;
+    while (yaw < -3.14159265f) yaw += 6.28318531f;
+    return yaw;
+}
+
+void PublishBodyYawBridgeDebugLocked() {
+    CyberpunkVR_BodyYawRealignRad = s_bodyYawBridge.activeCameraBridgeYaw;
+    CyberpunkVR_DebugBodyFollowOffsetDeg =
+        s_bodyYawBridge.activeCameraBridgeYaw * 57.2957795f;
+    s_bodyYawBridgeHasDebt.store(
+        s_bodyYawBridge.pendingGameYaw != 0.0f ||
+        s_bodyYawBridge.readyBaseFoldYaw != 0.0f ||
+        s_bodyYawBridge.activeCameraBridgeYaw != 0.0f ||
+        s_bodyYawBridge.previousEpochBridgeYaw != 0.0f,
+        std::memory_order_release);
+}
+
 // The HMD's yaw relative to the recenter base, radians, about the XR vertical (+Y).
-bool HeadYawRelBase(float* outYaw) {
+bool HeadYawRelBase(float* outYaw, uint64_t* outEpoch) {
     OpenXRHeadPose hp{};
     if (!OpenXRManager::Get().GetHeadPose(&hp) || !hp.valid) return false;
     const float y = hp.oriY, z = hp.oriZ, x = hp.oriX, w = hp.oriW;
     *outYaw = std::atan2(2.0f * (w * y + x * z), 1.0f - 2.0f * (y * y + z * z));
+    if (outEpoch) *outEpoch = hp.frameAimEpoch;
     return true;
 }
 
 }  // namespace
+
+extern "C" float BodyYawBridgeCurrentRealignRad() {
+    if (!s_bodyYawBridgeHasDebt.load(std::memory_order_acquire)) return 0.0f;
+    std::lock_guard<std::mutex> lock(s_bodyYawBridgeMutex);
+    return s_bodyYawBridge.activeCameraBridgeYaw;
+}
+
+extern "C" float BodyYawBridgeRealignForEpoch(uint64_t epoch) {
+    if (!s_bodyYawBridgeHasDebt.load(std::memory_order_acquire)) return 0.0f;
+    std::lock_guard<std::mutex> lock(s_bodyYawBridgeMutex);
+    if (epoch != 0 && epoch == s_bodyYawBridge.previousEpoch) {
+        return s_bodyYawBridge.previousEpochBridgeYaw;
+    }
+    return s_bodyYawBridge.activeCameraBridgeYaw;
+}
+
+extern "C" void BodyYawBridgeAcknowledgeRenderedCamera(uint64_t epoch, float bridgeUsed) {
+    if (!s_bodyYawBridgeHasDebt.load(std::memory_order_acquire)) return;
+    std::lock_guard<std::mutex> lock(s_bodyYawBridgeMutex);
+    if (epoch != 0 && epoch != s_bodyYawBridge.currentEpoch) return;
+    if (s_bodyYawBridge.pendingGameYaw == 0.0f) return;
+    const float bridgeWithoutPending =
+        WrapYaw(s_bodyYawBridge.activeCameraBridgeYaw - s_bodyYawBridge.pendingGameYaw);
+    float acknowledged = WrapYaw(bridgeUsed - bridgeWithoutPending);
+    const float pending = s_bodyYawBridge.pendingGameYaw;
+    if (pending > 0.0f) {
+        if (acknowledged < 0.0f) acknowledged = 0.0f;
+        if (acknowledged > pending) acknowledged = pending;
+    } else {
+        if (acknowledged > 0.0f) acknowledged = 0.0f;
+        if (acknowledged < pending) acknowledged = pending;
+    }
+    if (acknowledged == 0.0f) return;
+    s_bodyYawBridge.readyBaseFoldYaw += acknowledged;
+    s_bodyYawBridge.pendingGameYaw -= acknowledged;
+    PublishBodyYawBridgeDebugLocked();
+}
+
+extern "C" bool BodyYawBridgeNeedsProtection() {
+    return CyberpunkVR_BodyYawFollow != 0 ||
+        s_bodyYawBridgeHasDebt.load(std::memory_order_acquire);
+}
+
+extern "C" void BodyYawBridgeBeginXrEpoch(XrTime locateTime) {
+    auto& xr = OpenXRManager::Get();
+    std::lock_guard<std::mutex> lock(s_bodyYawBridgeMutex);
+    s_bodyYawBridge.previousEpoch = xr.GetFrameAimEpoch();
+    s_bodyYawBridge.previousEpochBridgeYaw = s_bodyYawBridge.activeCameraBridgeYaw;
+
+    // Keep advancing coherent pose epochs during a native LOCAL transition, but do not mutate
+    // the old-space base. The pending transaction will replace that base and discard all bridge
+    // state after the first valid new-space locate.
+    const float fold = xr.IsRuntimeLocalRecenterPending()
+        ? 0.0f
+        : s_bodyYawBridge.readyBaseFoldYaw;
+    const bool folded = xr.BeginFrameAimEpochWithBaseFold(locateTime, fold);
+    if (fold != 0.0f && folded) {
+        s_bodyYawBridge.activeCameraBridgeYaw =
+            WrapYaw(s_bodyYawBridge.activeCameraBridgeYaw - fold);
+        s_bodyYawBridge.readyBaseFoldYaw = 0.0f;
+    }
+
+    s_bodyYawBridge.currentEpoch = xr.GetFrameAimEpoch();
+    PublishBodyYawBridgeDebugLocked();
+}
+
+extern "C" void BodyYawBridgeResetForRecenter() {
+    std::lock_guard<std::mutex> lock(s_bodyYawBridgeMutex);
+    const uint64_t epoch = OpenXRManager::Get().GetFrameAimEpoch();
+    s_bodyYawBridge = {};
+    s_bodyYawBridge.currentEpoch = epoch;
+    s_bodyYawBridge.previousEpoch = ~0ull;
+    CyberpunkVR_DebugBodyFollowErrDeg = 0.0f;
+    PublishBodyYawBridgeDebugLocked();
+}
 
 // THE STEP TO INJECT INTO THE ENGINE'S HEADING THIS FRAME, radians. Called once per frame from the
 // on-foot heading hook, which is the game's own turn channel.
@@ -211,16 +311,23 @@ bool HeadYawRelBase(float* outYaw) {
 extern "C" float BodyYawFollowStep() {
     ++CyberpunkVR_DebugBodyFollowCalls;
     if (!CyberpunkVR_BodyYawFollow) {
-        // Give the realign back when the feature is switched off, or the view would keep the
-        // subtraction for as long as the session lasts.
-        CyberpunkVR_BodyYawRealignRad = 0.0f;
-        CyberpunkVR_DebugBodyFollowOffsetDeg = 0.0f;
+        // Preserve any in-flight compensation until the next epoch can fold it into the base.
+        std::lock_guard<std::mutex> lock(s_bodyYawBridgeMutex);
+        s_bodyYawBridge.readyBaseFoldYaw += s_bodyYawBridge.pendingGameYaw;
+        s_bodyYawBridge.pendingGameYaw = 0.0f;
+        PublishBodyYawBridgeDebugLocked();
         return 0.0f;
     }
+    // A native LOCAL recenter is a coordinate-system transaction, not physical head motion.
+    // Until the frame loop has captured m_basePose from a valid pose at/after changeTime, the
+    // cached relative head pose may combine the new LOCAL space with the old base. Never inject
+    // that discontinuity into the game's heading.
+    if (OpenXRManager::Get().IsRuntimeLocalRecenterPending()) return 0.0f;
     float hmdYaw = 0.0f;
-    if (!HeadYawRelBase(&hmdYaw)) return 0.0f;
+    uint64_t poseEpoch = 0;
+    if (!HeadYawRelBase(&hmdYaw, &poseEpoch)) return 0.0f;
 
-    float resid = hmdYaw - CyberpunkVR_BodyYawRealignRad;
+    float resid = hmdYaw - BodyYawBridgeRealignForEpoch(poseEpoch);
     while (resid >  3.14159265f) resid -= 6.28318531f;
     while (resid < -3.14159265f) resid += 6.28318531f;
     CyberpunkVR_DebugBodyFollowErrDeg = resid * 57.2957795f;
@@ -242,10 +349,14 @@ extern "C" float BodyYawFollowStep() {
     // refuses part of a large delta the view would drift by the refused part -- that would show up as
     // the view creeping during fast turns, and nothing else looks like it.
 
-    CyberpunkVR_BodyYawRealignRad += step;
-    while (CyberpunkVR_BodyYawRealignRad >  3.14159265f) CyberpunkVR_BodyYawRealignRad -= 6.28318531f;
-    while (CyberpunkVR_BodyYawRealignRad < -3.14159265f) CyberpunkVR_BodyYawRealignRad += 6.28318531f;
-    CyberpunkVR_DebugBodyFollowOffsetDeg = CyberpunkVR_BodyYawRealignRad * 57.2957795f;
+    {
+        std::lock_guard<std::mutex> lock(s_bodyYawBridgeMutex);
+        s_bodyYawBridge.pendingGameYaw += step;
+        s_bodyYawBridge.activeCameraBridgeYaw =
+            WrapYaw(s_bodyYawBridge.activeCameraBridgeYaw + step);
+        s_bodyYawBridge.currentEpoch = OpenXRManager::Get().GetFrameAimEpoch();
+        PublishBodyYawBridgeDebugLocked();
+    }
     ++CyberpunkVR_DebugBodyFollowApplied;
     return step;
 }

--- a/src/Hooks/LocateCamera.cpp
+++ b/src/Hooks/LocateCamera.cpp
@@ -452,18 +452,6 @@ extern "C" void __fastcall OnLocateCameraCallback(float* rbxPtr, float xmm0_val)
     // carried +50.69 (the same value the solve converted with, so the frames agreed) while the
     // published view carried +50.69 too, when the drawn view was at -42.00.
     //
-    // Taking it out once, here, fixes every consumer at the source instead of one at a time.
-    if (CyberpunkVR_BodyYawRealignRad != 0.0f) {
-        const float ra = -CyberpunkVR_BodyYawRealignRad;
-        const float cr = cosf(ra), sr = sinf(ra);
-        const float fx = bodyGameForwardX * cr - bodyGameForwardY * sr;
-        const float fy = bodyGameForwardX * sr + bodyGameForwardY * cr;
-        bodyGameForwardX = fx;
-        bodyGameForwardY = fy;
-    }
-
-
-
     // POSE PAIR LOCKING: fetch the render eye FIRST, then take a pair-locked head
     // pose — eye0 samples live + freezes, eye1 replays eye0's pose. Both eyes of
     // the stereo pair therefore drive the camera (and below, VRIK) from ONE head
@@ -494,6 +482,19 @@ extern "C" void __fastcall OnLocateCameraCallback(float* rbxPtr, float xmm0_val)
     const bool hasXR = CyberpunkVR_OneSamplePerFrame
         ? OpenXRManager::Get().AcquireFrameHeadSample(&xrPose)
         : OpenXRManager::Get().GetHeadPose(&xrPose);
+    // Take the bridge value belonging to the same base/aim epoch as this head pose. A late camera
+    // consumer can still finish an older epoch after the XR thread has folded the new one.
+    const float bodyYawBridge = hasXR
+        ? BodyYawBridgeRealignForEpoch(xrPose.frameAimEpoch)
+        : BodyYawBridgeCurrentRealignRad();
+    if (bodyYawBridge != 0.0f) {
+        const float ra = -bodyYawBridge;
+        const float cr = cosf(ra), sr = sinf(ra);
+        const float fx = bodyGameForwardX * cr - bodyGameForwardY * sr;
+        const float fy = bodyGameForwardX * sr + bodyGameForwardY * cr;
+        bodyGameForwardX = fx;
+        bodyGameForwardY = fy;
+    }
     const bool composeAtWrite = (CyberpunkVR_CamWriteInPatch && CyberpunkVR_CamComposeAtWrite);
     if (hasXR) {
         // Hand the EXACT sample this frame's camera is built from to the submit path, so

--- a/src/Hooks/OnFootDeltaHead.cpp
+++ b/src/Hooks/OnFootDeltaHead.cpp
@@ -35,7 +35,6 @@ extern "C" void __fastcall OnOnFootDeltaHeadCallback(float* deltaHead) {
         g_telemetry->deltaHeadRcx = reinterpret_cast<uintptr_t>(deltaHead);
     }
     if (!deltaHead) return;
-    if(g_isInVehicle) return;
 
     // Physical body rotation (F10 -> VRIK). OFF (default): no continuous body-yaw
     // tracking from the HMD -- only the discrete snap-turn is applied (classic heading).
@@ -43,6 +42,10 @@ extern "C" void __fastcall OnOnFootDeltaHeadCallback(float* deltaHead) {
     // path test on their hot paths, and it is set from here so the two can never disagree.
     const bool bodyRot = g_liveControls.xrPhysicalBodyRotation != 0;
     CyberpunkVR_BodyYawFollow = bodyRot ? 1 : 0;
+    if(g_isInVehicle) {
+        if (!bodyRot) BodyYawFollowStep();
+        return;
+    }
 
     // MEASUREMENT ONLY. Cancelling the weapon's camera kick HERE was built and taken out again on the
     // user's call: hiding it in the view leaves the game still applying it to the character, and the
@@ -106,6 +109,10 @@ extern "C" void __fastcall OnOnFootDeltaHeadCallback(float* deltaHead) {
     // bodyRot OFF (default) -> classic snap-turn only: the heading never tracks the
     // head; the camera composes heading * FULL HMD, so a head turn moves ONLY the view.
     if (!bodyRot) {
+        // Switching the feature off may leave one acknowledged/unacknowledged bridge step in
+        // flight. Move it to the fold queue before returning; once that debt retires the XR loop
+        // returns to the original SetFrameAimTime fast path.
+        BodyYawFollowStep();
         deltaHead[idx] += snap;
         return;
     }
@@ -124,16 +131,13 @@ extern "C" void __fastcall OnOnFootDeltaHeadCallback(float* deltaHead) {
     // account. What rules that route out is the gameplay half: aim, movement, cover and
     // the collision capsule come from this heading, not from those transforms.
     //
-    // THE RECENTER BASE IS NOT TOUCHED. The version of this that shipped before called
-    // RotateBaseYaw(step) to cancel the view, which is right in the algebra and wrong in
-    // the ORDER: the heading changes here, inside the game tick, while the base only takes
-    // effect on the next XR cycle, so for one frame the view swings by the whole step --
-    // the camera drift this feature was always reported to have. The cancellation now
-    // happens on our side of the same frame, in the camera write and in the head-offset
-    // recipe, both of which compose from (engine yaw - CyberpunkVR_BodyYawRealignRad).
-    // Recentring therefore keeps working exactly as it did with the feature off.
+    // The heading changes here inside the game tick. A temporary camera bridge cancels the
+    // same step in that rendered frame; after the camera acknowledges it, the next safe XR
+    // epoch folds the step into the recenter base and retires the bridge. Rendered poses keep
+    // the base snapshot from their own epoch, so the fold cannot relabel an older frame.
+    // Recenter clears any in-flight bridge debt together with the base.
     //
-    // The loop, the cone and the realign accumulator live in src/Hooks/BodyYawFollow.cpp;
+    // The loop, the cone and the bridge state live in src/Hooks/BodyYawFollow.cpp;
     // this file is only the door into the engine's heading.
     if (g_menuModeValue == 0) {
         const float step = BodyYawFollowStep();         // radians, 0 when inside the cone

--- a/src/Hooks/OnFootMoveXY.cpp
+++ b/src/Hooks/OnFootMoveXY.cpp
@@ -11,7 +11,7 @@
 #include "Utils/MemorySafe.hpp"
 #include "Core/Telemetry.hpp"
 #include "Core/LiveControls.hpp"
-#include "Camera/CameraState.hpp"   // CyberpunkVR_BodyYawRealignRad
+#include "Camera/CameraState.hpp"   // BodyYawBridgeCurrentRealignRad
 #include "Runtimes/OpenXRManager.hpp"
 
 #include <windows.h>
@@ -52,10 +52,10 @@ extern "C" void OnOnFootMoveXYCallback(void* moveStruct) {
     // injected into that heading, and it has to come back out here or walking drifts from the gaze by
     // the amount the body has turned.
     //
-    // It used to cancel by itself: the old realign rotated the recenter base by the same angle, which
-    // moved base-relative and heading-relative into step. That base rotation is gone (it landed a
-    // frame late and swung the view), so the subtraction is explicit now. Zero when the feature is off.
-    yaw -= CyberpunkVR_BodyYawRealignRad;
+    // While a heading step is still in flight, its temporary camera bridge must also be removed here.
+    // Once the next XR epoch folds that step into the base, base-relative and heading-relative yaw
+    // match again and the bridge retires. Zero when the feature is off or no step is in flight.
+    yaw -= BodyYawBridgeCurrentRealignRad();
     float c = cosf(yaw);
     float s = sinf(yaw);
     p[0] = x * c - y * s;

--- a/src/Hooks/PatchCamera.cpp
+++ b/src/Hooks/PatchCamera.cpp
@@ -392,16 +392,18 @@ extern "C" void __fastcall OnPatchCameraCallback(float* cameraState, void* owner
                         // The body follower turns the character through the engine's own heading (see
                         // src/Hooks/BodyYawFollow.cpp), and that heading is what this composition is
                         // built from -- so without this line every degree the body gains would swing
-                        // the view with it. Subtracting the accumulated realign leaves the view
-                        // exactly where it would have been had the body never turned, in the SAME
-                        // frame the heading changed.
+                        // the view with it. Subtracting the temporary bridge leaves the view exactly
+                        // where it would have been had the body never turned, in the SAME frame the
+                        // heading changed.
                         //
-                        // This is where the cancellation belongs. Doing it by rotating the recenter
-                        // base is algebraically identical but lands a frame late -- the heading moves
-                        // in the game tick, the base only on the next XR cycle -- and that one frame
-                        // of uncancelled step is the camera drift the old on-foot realign had.
-                        // Leaving the base alone also means recentring is untouched by the feature.
-                        yaw -= CyberpunkVR_BodyYawRealignRad;
+                        // This bridge is necessary until the camera acknowledges the step. The next
+                        // safe XR epoch then folds the acknowledged yaw into the recenter base and
+                        // retires the same amount from the bridge.
+                        const float bodyYawBridge = BodyYawBridgeRealignForEpoch(p.frameAimEpoch);
+                        yaw -= bodyYawBridge;
+                        // This camera is now composed from the heading that includes the follower's
+                        // requested turn. The next XR epoch may safely fold that acknowledged yaw.
+                        BodyYawBridgeAcknowledgeRenderedCamera(p.frameAimEpoch, bodyYawBridge);
                         // PUBLISHED AT THE INSTANT IT IS USED, so the play-space anchor can be rotated by
                         // the very same number instead of by the body's own forward. Those were two clocks
                         // -- this one is assembled per rendered frame, the body's advances on the entity
@@ -732,7 +734,7 @@ extern "C" void __fastcall OnPatchCameraCallback(float* cameraState, void* owner
             static bool  s_mountLearned = false;
             const float kFp = 1.0f / 131072.0f;
             const float H = CyberpunkVR_BodyYawFinalRad;
-            const float A = CyberpunkVR_BodyYawRealignRad;
+            const float A = BodyYawBridgeCurrentRealignRad();
             const float rx = static_cast<float>(p[0]) * kFp - CyberpunkVR_PlayerEntityPos[0];
             const float ry = static_cast<float>(p[1]) * kFp - CyberpunkVR_PlayerEntityPos[1];
             if (A == 0.0f) {

--- a/src/Runtimes/OpenXRCalibration.cpp
+++ b/src/Runtimes/OpenXRCalibration.cpp
@@ -15,23 +15,38 @@
 #include <chrono>
 #include <algorithm>
 
-void OpenXRManager::RotateBaseYaw(float radians) {
-    // Rotate the recenter base about vertical (XR +Y) so the HMD's base-relative yaw
-    // shifts by -radians. Called by the dxgi body-realign logic together with an equal
-    // heading injection; the pair leaves the rendered view and the HMD-local hand
-    // poses stationary while the body turns underneath.
-    if (radians == 0.0f) return;
-    std::lock_guard<std::mutex> lock(m_renderPoseMutex);
-    if (!m_basePoseSet) return;
+namespace {
+void RotatePoseYaw(XrPosef& pose, float radians) {
     const float h = radians * 0.5f;
     const XrQuaternionf ry{0.0f, sinf(h), 0.0f, cosf(h)};
-    XrQuaternionf q = MultiplyQuat(m_basePose.orientation, ry);
+    XrQuaternionf q = MultiplyQuat(pose.orientation, ry);
     const float n = sqrtf(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
     if (n > 1e-8f) {
         const float inv = 1.0f / n;
         q.x *= inv; q.y *= inv; q.z *= inv; q.w *= inv;
     }
-    m_basePose.orientation = q;
+    pose.orientation = q;
+}
+}  // namespace
+
+bool OpenXRManager::BeginFrameAimEpochWithBaseFold(XrTime t, float foldYaw) {
+    // AcquireFrameHeadSample uses this mutex at both ends of its locate. The render-pose mutex
+    // additionally makes the base mutation and epoch bump indivisible to direct locate callers.
+    std::lock_guard<std::mutex> sampleLock(m_frameSampleMutex);
+    bool folded = foldYaw == 0.0f;
+    {
+        std::lock_guard<std::mutex> renderLock(m_renderPoseMutex);
+        if (foldYaw != 0.0f && m_basePoseSet) {
+            RotatePoseYaw(m_basePose, foldYaw);
+            ++m_basePoseGeneration;
+            PublishRecenterBase(m_basePose);
+            folded = true;
+        }
+        SetFrameAimTime(t);
+    }
+    m_frameSample = {};
+    m_frameSampleEpoch = ~0ull;
+    return folded;
 }
 
 void OpenXRManager::RequestRecenter() {

--- a/src/Runtimes/OpenXRFrameLoop.cpp
+++ b/src/Runtimes/OpenXRFrameLoop.cpp
@@ -23,6 +23,10 @@
 #include <dxgi1_4.h>
 #include "Utils/LogThrottle.hpp"
 
+extern "C" void BodyYawBridgeBeginXrEpoch(XrTime locateTime);
+extern "C" void BodyYawBridgeResetForRecenter();
+extern "C" bool BodyYawBridgeNeedsProtection();
+
 // Run the XR cycle on every display frame and let xrWaitFrame pace it, re-submitting the
 // last snapshot with ITS OWN pose when the game has not produced a new one. 0 restores the
 // old behaviour (block until a fresh game frame, skipping XR frames entirely).
@@ -1161,7 +1165,13 @@ DWORD OpenXRManager::FrameThreadMain() {
         }
         // Publish it so the camera write aims at the very same instant instead of deriving its
         // own -- see SetFrameAimTime().
-        SetFrameAimTime(locateTime);
+        // Physical body rotation owns the bridge/base-fold transaction. With the feature off and
+        // no in-flight debt, preserve the original frame-aim path exactly.
+        if (IsRuntimeLocalRecenterPending() || BodyYawBridgeNeedsProtection()) {
+            BodyYawBridgeBeginXrEpoch(locateTime);
+        } else {
+            SetFrameAimTime(locateTime);
+        }
 
 
         // The controllers use the same target as the head. See the note at the top of this file.
@@ -1251,10 +1261,23 @@ DWORD OpenXRManager::FrameThreadMain() {
 
         if (headPoseLocated) {
             XrPosef basePose{};
+            uint64_t baseGeneration = 0;
             bool baseReset = false;
+            const bool runtimeLocalRecenterPending =
+                m_runtimeLocalRecenterPending.load(std::memory_order_acquire);
+            const XrTime runtimeLocalChangeTime =
+                m_runtimeLocalRecenterChangeTime.load(std::memory_order_relaxed);
+            const bool runtimeLocalRecenterDue = runtimeLocalRecenterPending &&
+                locateTime >= runtimeLocalChangeTime;
+            // Do not consume a mod recenter request into the old LOCAL space while a native
+            // transition is pending. If both coincide, the coherent native-space capture satisfies
+            // both requests and consumes the mod request at the same boundary.
+            const bool modRecenterRequested =
+                (!runtimeLocalRecenterPending || runtimeLocalRecenterDue) &&
+                m_recenterRequested.exchange(false, std::memory_order_relaxed);
             {
                 std::lock_guard<std::mutex> renderLock(m_renderPoseMutex);
-                if (!m_basePoseSet || m_recenterRequested.exchange(false, std::memory_order_relaxed)) {
+                if (!m_basePoseSet || modRecenterRequested || runtimeLocalRecenterDue) {
                     // YAW-ONLY BASE (native-VR recenter semantics). The old code captured the
                     // FULL HMD orientation -- whatever pitch/roll the user's head held at that
                     // moment got baked into the base, and conj(base)*pose then TILTED THE WORLD
@@ -1277,14 +1300,32 @@ DWORD OpenXRManager::FrameThreadMain() {
                     m_basePose.position = location.pose.position;
                     m_basePose.orientation = XrQuaternionf{0.0f, sinf(yaw*0.5f), 0.0f, cosf(yaw*0.5f)};
                     m_basePoseSet = true;
+                    ++m_basePoseGeneration;
                     baseReset = true;
                     Log("OpenXRManager: Base pose captured (yaw-only, %.1f deg).\n", yaw * 57.29578f);
                 }
                 basePose = m_basePose;
+                baseGeneration = m_basePoseGeneration;
             }
             // Mirror it for the submit path, which has to undo this transform to put a rendered
             // pose back into local space. See GetRecenterBase().
             PublishRecenterBase(basePose);
+            const bool resetPbrState = runtimeLocalRecenterPending ||
+                BodyYawBridgeNeedsProtection();
+            if (baseReset && resetPbrState) {
+                BodyYawBridgeResetForRecenter();
+                {
+                    std::lock_guard<std::mutex> sampleLock(m_frameSampleMutex);
+                    m_frameSample = {};
+                    m_frameSampleEpoch = ~0ull;
+                }
+                if (runtimeLocalRecenterDue) {
+                    // Resume only after the new base and all old bridge/sample state are gone.
+                    m_runtimeLocalRecenterPending.store(false, std::memory_order_release);
+                    Log("OpenXRManager: LOCAL recenter committed at locateTime=%lld; "
+                        "body follow resumed.\n", static_cast<long long>(locateTime));
+                }
+            }
 
             XrQuaternionf baseInv = ConjugateQuat(basePose.orientation);
             XrVector3f relPosWorld{};
@@ -1296,7 +1337,10 @@ DWORD OpenXRManager::FrameThreadMain() {
             XrPosef filteredHeadPose{};
             filteredHeadPose.position = relPos;
             filteredHeadPose.orientation = relOri;
-            if (baseReset) {
+            static uint64_t s_filterBaseGeneration = 0;
+            const bool baseGenerationChanged = s_filterBaseGeneration != baseGeneration;
+            s_filterBaseGeneration = baseGeneration;
+            if (baseReset || baseGenerationChanged) {
                 m_headFilterState.initialized = false;
                 m_handAimYawFilter[0].initialized = false;
                 m_handAimYawFilter[1].initialized = false;
@@ -1353,7 +1397,10 @@ DWORD OpenXRManager::FrameThreadMain() {
                     s_q = NlerpQuat(s_q, filteredHeadPose.orientation, t);
                 }
                 s_lastUs = nowUs;
-                if (baseReset) { s_p = filteredHeadPose.position; s_q = filteredHeadPose.orientation; }
+                if (baseReset || baseGenerationChanged) {
+                    s_p = filteredHeadPose.position;
+                    s_q = filteredHeadPose.orientation;
+                }
                 filteredHeadPose.position = s_p;
                 filteredHeadPose.orientation = s_q;
                 m_headFilterState.initialized = false;
@@ -1378,14 +1425,20 @@ DWORD OpenXRManager::FrameThreadMain() {
                                  static_cast<uint32_t>(m_views.size()), location.pose);
             }
 
-            m_posX.store(filteredHeadPose.position.x, std::memory_order_relaxed);
-            m_posY.store(filteredHeadPose.position.y, std::memory_order_relaxed);
-            m_posZ.store(filteredHeadPose.position.z, std::memory_order_relaxed);
-            m_oriX.store(filteredHeadPose.orientation.x, std::memory_order_relaxed);
-            m_oriY.store(filteredHeadPose.orientation.y, std::memory_order_relaxed);
-            m_oriZ.store(filteredHeadPose.orientation.z, std::memory_order_relaxed);
-            m_oriW.store(filteredHeadPose.orientation.w, std::memory_order_relaxed);
-            m_poseValid.store(true, std::memory_order_relaxed);
+            {
+                std::lock_guard<std::mutex> cachedLock(m_cachedHeadPoseMutex);
+                m_posX.store(filteredHeadPose.position.x, std::memory_order_relaxed);
+                m_posY.store(filteredHeadPose.position.y, std::memory_order_relaxed);
+                m_posZ.store(filteredHeadPose.position.z, std::memory_order_relaxed);
+                m_oriX.store(filteredHeadPose.orientation.x, std::memory_order_relaxed);
+                m_oriY.store(filteredHeadPose.orientation.y, std::memory_order_relaxed);
+                m_oriZ.store(filteredHeadPose.orientation.z, std::memory_order_relaxed);
+                m_oriW.store(filteredHeadPose.orientation.w, std::memory_order_relaxed);
+                m_cachedHeadBase = basePose;
+                m_cachedHeadBaseGeneration = baseGeneration;
+                m_cachedHeadFrameAimEpoch = GetFrameAimEpoch();
+                m_poseValid.store(true, std::memory_order_release);
+            }
 
             // [HANDS] Sync actions and locate hands
             static int s_handLogCounter = 0;

--- a/src/Runtimes/OpenXRManager.cpp
+++ b/src/Runtimes/OpenXRManager.cpp
@@ -43,6 +43,7 @@ extern volatile int g_verboseLog; // gate per-frame hand-tracking spam
 extern "C" int GetDisableRoll();
 extern "C" float GetForcedFov();
 extern "C" float GetGameRenderFovDeg(); // FOV (deg) the game actually renders with (native or forced); 0 if unknown
+extern "C" bool BodyYawBridgeNeedsProtection();
 extern "C" float GetTargetRenderVfovDegC(); // overscanned vertical FOV (deg) the game renders = lens*overscan; 0 if unknown
 extern "C" float GetMenuFov();
 extern "C" float GetMenuFollowDeg(); // head-vs-panel yaw offset (deg) that starts the lazy menu re-center
@@ -570,7 +571,7 @@ OpenXRManager& OpenXRManager::Get() {
     return instance;
 }
 
-// [recenter / auto-calibration / calibration-file methods (RotateBaseYaw ... LoadCalibrationFromFile) moved to openxr_calibration.cpp]
+// [recenter / auto-calibration / calibration-file methods moved to openxr_calibration.cpp]
 
 void OpenXRManager::SetMonoSubmitEnabled(bool enabled) {
     m_monoSubmitEnabled.store(enabled, std::memory_order_relaxed);
@@ -1036,15 +1037,28 @@ void OpenXRManager::PollEvents() {
                 m_stopFrameThread.store(true, std::memory_order_relaxed);
             }
         } else if (event.type == XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING) {
-            // Native OpenXR recenter (user held the home / system button, or used the runtime menu) —
-            // the runtime is about to remap "forward" of its tracking space at changed->changeTime.
-            // Trigger our local recenter so the mod's stored base pose lines up with the runtime's
-            // new tracking space; the next frame's HMD pose then reads (0,0,0,facing-forward) as the
-            // user expects.
             auto* changed = reinterpret_cast<XrEventDataReferenceSpaceChangePending*>(&event);
-            Log("OpenXRManager: Tracking space change pending (native recenter), refSpace=%d -> local recenter.\n",
-                static_cast<int>(changed->referenceSpaceType));
-            RequestRecenter();
+            const bool pbrGuard = BodyYawBridgeNeedsProtection();
+            if (!pbrGuard) {
+                // Original native-reset path. Physical body rotation is off and there is no bridge
+                // debt, so do not route ordinary Oculus recenter through the PBR transaction.
+                Log("OpenXRManager: Tracking space change pending (native recenter), refSpace=%d "
+                    "-> original local recenter path.\n",
+                    static_cast<int>(changed->referenceSpaceType));
+                RequestRecenter();
+            } else if (changed->referenceSpaceType == XR_REFERENCE_SPACE_TYPE_LOCAL) {
+                // PBR adds an HMD-yaw consumer. Freeze only that feature until LOCAL has crossed
+                // changeTime and a coherent new-space base can replace the old one.
+                m_runtimeLocalRecenterChangeTime.store(changed->changeTime,
+                                                       std::memory_order_relaxed);
+                m_runtimeLocalRecenterPending.store(true, std::memory_order_release);
+                Log("OpenXRManager: LOCAL space change pending (native recenter), changeTime=%lld; "
+                    "body follow frozen.\n", static_cast<long long>(changed->changeTime));
+            } else {
+                Log("OpenXRManager: Tracking space change pending, refSpace=%d ignored "
+                    "(PBR guard uses LOCAL as authority).\n",
+                    static_cast<int>(changed->referenceSpaceType));
+            }
         }
 
         event = {XR_TYPE_EVENT_DATA_BUFFER};
@@ -1246,10 +1260,14 @@ bool OpenXRManager::LocateHeadPoseAt(XrTime displayTime, OpenXRHeadPose* out) {
     // Same recenter transform the frame loop applies, so this pose is interchangeable with
     // GetHeadPose()'s: relOri = conj(base.ori) * raw, relPos = conj(base.ori) * (raw - base.pos).
     XrPosef base{};
+    uint64_t baseGeneration = 0;
+    uint64_t poseEpoch = 0;
     {
         std::lock_guard<std::mutex> lock(m_renderPoseMutex);
         if (!m_basePoseSet) return false;
         base = m_basePose;
+        baseGeneration = m_basePoseGeneration;
+        poseEpoch = GetFrameAimEpoch();
     }
     const XrQuaternionf baseInv = ConjugateQuat(base.orientation);
     const XrVector3f relWorld{ loc.pose.position.x - base.position.x,
@@ -1295,12 +1313,15 @@ bool OpenXRManager::LocateHeadPoseAt(XrTime displayTime, OpenXRHeadPose* out) {
     if (CyberpunkVR_PredictFilter) {
         static std::mutex s_mtx;
         static bool s_init = false;
+        static uint64_t s_baseGeneration = 0;
         static XrVector3f s_pos{};
         static XrQuaternionf s_ori{0.0f, 0.0f, 0.0f, 1.0f};
         const float strength = GetHmdTrackingSmooth();
         std::lock_guard<std::mutex> lock(s_mtx);
-        if (!s_init || (CyberpunkVR_PredictFilter == 1 && strength <= 0.001f)) {
+        if (!s_init || s_baseGeneration != baseGeneration ||
+            (CyberpunkVR_PredictFilter == 1 && strength <= 0.001f)) {
             s_init = true;
+            s_baseGeneration = baseGeneration;
             s_pos = relPos;
             s_ori = relOri;
         } else if (CyberpunkVR_PredictFilter == 3) {
@@ -1399,18 +1420,25 @@ bool OpenXRManager::LocateHeadPoseAt(XrTime displayTime, OpenXRHeadPose* out) {
         out->valid = true;
         out->posX = s_pos.x;  out->posY = s_pos.y;  out->posZ = s_pos.z;
         out->oriX = s_ori.x;  out->oriY = s_ori.y;  out->oriZ = s_ori.z;  out->oriW = s_ori.w;
+        out->recenterBase = base;
+        out->recenterBaseValid = true;
+        out->frameAimEpoch = poseEpoch;
         return true;
     }
 
     out->valid = true;
     out->posX = relPos.x;  out->posY = relPos.y;  out->posZ = relPos.z;
     out->oriX = relOri.x;  out->oriY = relOri.y;  out->oriZ = relOri.z;  out->oriW = relOri.w;
+    out->recenterBase = base;
+    out->recenterBaseValid = true;
+    out->frameAimEpoch = poseEpoch;
     return true;
 }
 
 bool OpenXRManager::GetHeadPose(OpenXRHeadPose* out) const {
     if (!out) return false;
 
+    std::lock_guard<std::mutex> cachedLock(m_cachedHeadPoseMutex);
     const bool useSyncedPose = GetSyncSequential() != 0 && m_syncedPoseValid.load(std::memory_order_relaxed);
     out->valid = useSyncedPose ? true : m_poseValid.load(std::memory_order_relaxed);
     out->posX = useSyncedPose ? m_syncedPosX.load(std::memory_order_relaxed) : m_posX.load(std::memory_order_relaxed);
@@ -1420,6 +1448,9 @@ bool OpenXRManager::GetHeadPose(OpenXRHeadPose* out) const {
     out->oriY = useSyncedPose ? m_syncedOriY.load(std::memory_order_relaxed) : m_oriY.load(std::memory_order_relaxed);
     out->oriZ = useSyncedPose ? m_syncedOriZ.load(std::memory_order_relaxed) : m_oriZ.load(std::memory_order_relaxed);
     out->oriW = useSyncedPose ? m_syncedOriW.load(std::memory_order_relaxed) : m_oriW.load(std::memory_order_relaxed);
+    out->recenterBase = m_cachedHeadBase;
+    out->recenterBaseValid = m_cachedHeadBaseGeneration != 0;
+    out->frameAimEpoch = m_cachedHeadFrameAimEpoch;
 
     // MOTION PREDICTION REMOVED (xr_motion_predict_ms).
     //
@@ -1485,12 +1516,13 @@ void OpenXRManager::StoreRenderEyePose(int eye, const OpenXRHeadPose& pose, uint
     const XrVector3f relPos{pose.posX, pose.posY, pose.posZ};
     XrPosef raw;
     std::lock_guard<std::mutex> lock(m_renderPoseMutex);
-    if (m_basePoseSet) {
-        raw.orientation = MultiplyQuat(m_basePose.orientation, relOri);
-        const XrVector3f rotated = RotateVector(m_basePose.orientation, relPos);
-        raw.position = {m_basePose.position.x + rotated.x,
-                        m_basePose.position.y + rotated.y,
-                        m_basePose.position.z + rotated.z};
+    const XrPosef base = pose.recenterBaseValid ? pose.recenterBase : m_basePose;
+    if (pose.recenterBaseValid || m_basePoseSet) {
+        raw.orientation = MultiplyQuat(base.orientation, relOri);
+        const XrVector3f rotated = RotateVector(base.orientation, relPos);
+        raw.position = {base.position.x + rotated.x,
+                        base.position.y + rotated.y,
+                        base.position.z + rotated.z};
     } else {
         raw.orientation = relOri;
         raw.position = relPos;

--- a/src/Runtimes/OpenXRPresent.cpp
+++ b/src/Runtimes/OpenXRPresent.cpp
@@ -622,10 +622,14 @@ void OpenXRManager::OnPresent(IDXGISwapChain* swapChain) {
                 // struct AwaitFrame filled.
                 //
                 // And the space: GetHeadPose() is recenter-relative, the layer is m_localSpace.
-                // Undo the base here rather than shipping a pose from the wrong frame of
-                // reference (identity base hides it; a recenter does not).
+                // Restore the exact base snapshot saved with this rendered pose; using the live
+                // base after an epoch fold would relabel an older image with a newer reference.
                 XrPosef base{};
-                OpenXRManager::Get().GetRecenterBase(&base);
+                if (pending.recenterBaseValid) {
+                    base = pending.recenterBase;
+                } else {
+                    OpenXRManager::Get().GetRecenterBase(&base);
+                }
                 const XrQuaternionf relOri{ pending.oriX, pending.oriY, pending.oriZ, pending.oriW };
                 const XrVector3f relPos{ pending.posX, pending.posY, pending.posZ };
                 const XrVector3f rotated = RotateVector(base.orientation, relPos);
@@ -649,7 +653,11 @@ void OpenXRManager::OnPresent(IDXGISwapChain* swapChain) {
                 OpenXRHeadPose vrPending{};
                 if (OpenXRManager::Get().PopVrcamRenderedFramePose(&vrPending) && vrPending.valid) {
                     XrPosef vbase{};
-                    OpenXRManager::Get().GetRecenterBase(&vbase);
+                    if (vrPending.recenterBaseValid) {
+                        vbase = vrPending.recenterBase;
+                    } else {
+                        OpenXRManager::Get().GetRecenterBase(&vbase);
+                    }
                     const XrQuaternionf relOriV{ vrPending.oriX, vrPending.oriY,
                                                  vrPending.oriZ, vrPending.oriW };
                     const XrVector3f relPosV{ vrPending.posX, vrPending.posY, vrPending.posZ };


### PR DESCRIPTION
Fixes #61.

The previous Physical Body Rotation implementation avoided the old view jumping / snap-back by keeping the recenter base unchanged and compensating the body turn on the camera side instead.

That made the view stable, but it also meant the game heading and the VR base could gradually become two different references. The body could visually and physically face the new direction while `m_basePose` still considered the old direction to be forward.

This PR keeps the smooth behavior while bringing the VR base back into sync.

### What changed

* Body rotation still goes through the game's own heading channel.
* A temporary camera bridge cancels the extra view rotation immediately, so the headset view does not jump while the game heading changes.
* Once the matching camera frame has actually rendered, that rotation is folded into `m_basePose` at the next XR epoch and removed from the temporary bridge.
* Rendered poses keep the exact recenter-base snapshot they were created with, so an older queued frame cannot accidentally be submitted using a newer base.
* Native Oculus/OpenXR recenter is guarded while Physical Body Rotation is active, so a `LOCAL` reference-space change cannot be mistaken for a huge physical head turn.
* When Physical Body Rotation is off and there is no unfinished bridge state, the original recenter and frame-aim paths are left unchanged.

The result is that the body/game heading and VR reference now settle to the same orientation without bringing back the original one-frame view jump / snap-back.
