### PR TITLE
Pretty, distance-scaled laser dot with NPC occlusion fix

### DIFF
--- a/include/Core/LiveControls.hpp
+++ b/include/Core/LiveControls.hpp
@@ -47,6 +47,8 @@ struct LiveControls {
     volatile float xrSnapTurnAngleDeg; // degrees per snap pulse
     volatile int xrMovementSource;  // 0 = Game, 1 = HMD, 2 = LeftHand, 3 = RightHand
     volatile int xrLaserDotMode = 1; // 0 = steady projection, 1 = real world point, 2 = surface raycast
+    volatile float xrLaserDotRadiusMm = 6.0f; // apparent world-space radius in millimetres
+    volatile int xrLaserDotScaleWithDistance = 0; // mode 2 only: use the surface depth instead of the 2 m reference depth
     volatile int xrXInputInstall;   // 1 = install the XInput entry-point detour at startup (default 1, set 0 in vrport.ini to fully bypass)
     volatile int xrInputActions;    // 1 = create gameplay XrActions (thumbstick/trigger/buttons). 0 = pose-only legacy behaviour
     volatile int xrMonoXQueueWait;  // 1 = mono path inserts cross-queue Wait before depth capture (legacy). 0 = skip it -- avoids CP2077 async-compute Wait cycle that froze present thread.

--- a/include/Core/LiveControls.hpp
+++ b/include/Core/LiveControls.hpp
@@ -46,6 +46,7 @@ struct LiveControls {
     volatile int xrSnapTurn;        // 1 = discrete snap turn from right-stick X
     volatile float xrSnapTurnAngleDeg; // degrees per snap pulse
     volatile int xrMovementSource;  // 0 = Game, 1 = HMD, 2 = LeftHand, 3 = RightHand
+    volatile int xrLaserDotMode = 1; // 0 = steady projection, 1 = real world point, 2 = surface raycast
     volatile int xrXInputInstall;   // 1 = install the XInput entry-point detour at startup (default 1, set 0 in vrport.ini to fully bypass)
     volatile int xrInputActions;    // 1 = create gameplay XrActions (thumbstick/trigger/buttons). 0 = pose-only legacy behaviour
     volatile int xrMonoXQueueWait;  // 1 = mono path inserts cross-queue Wait before depth capture (legacy). 0 = skip it -- avoids CP2077 async-compute Wait cycle that froze present thread.

--- a/include/Natives/NativeFunctions.hpp
+++ b/include/Natives/NativeFunctions.hpp
@@ -135,6 +135,8 @@ void VRScannerSlotSet(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32
 void VRScannerSlotSave(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t);
 // 1 while a device screen (computer, terminal) is up; lets the right stick's Y reach the game's UI.
 void SetVRDeviceScreen(RED4ext::IScriptable* aContext, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t a4);
+void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);
+void QueryVRNpcHitSurface(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, RED4ext::Vector4* aOut, int64_t);
 void SetVRMuzzlePos(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);
 void SetVRMuzzleQuat(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);
 void SetVRPairLead(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t);

--- a/include/Overlay/LiveControlsUi.hpp
+++ b/include/Overlay/LiveControlsUi.hpp
@@ -48,6 +48,9 @@ struct LiveControlsUiState {
     int xrMovementSource;
     // Laser dot projection mode. 0 = steady projection, 1 = real world point, 2 = surface raycast.
     int xrLaserDotMode;
+    // World-space radius in millimetres. Distance scaling applies only to surface raycast mode.
+    float xrLaserDotRadiusMm;
+    int xrLaserDotScaleWithDistance;
     // Kill-switches for the new controller pipeline; default 0 (off) so a stuck
     // OpenXR binding or XInput entry-point patch can't keep CP2077 from booting.
     int xrXInputInstall;

--- a/include/Overlay/LiveControlsUi.hpp
+++ b/include/Overlay/LiveControlsUi.hpp
@@ -46,6 +46,8 @@ struct LiveControlsUiState {
     // 0..3 enum (0=Game, 1=HMD, 2=LeftHand, 3=RightHand). The overlay edits the
     // latter and the proxy mirrors it back into the legacy field.
     int xrMovementSource;
+    // Laser dot projection mode. 0 = steady projection, 1 = real world point, 2 = surface raycast.
+    int xrLaserDotMode;
     // Kill-switches for the new controller pipeline; default 0 (off) so a stuck
     // OpenXR binding or XInput entry-point patch can't keep CP2077 from booting.
     int xrXInputInstall;

--- a/include/Overlay/OverlayInternal.hpp
+++ b/include/Overlay/OverlayInternal.hpp
@@ -33,6 +33,9 @@ extern bool g_drawHandLocator;
 extern bool g_drawHandProxy3D;
 extern float g_aimRayLenM;
 extern float g_handLocatorScale;
+// A per-frame draw list that contains only geometry projected for the second eye. It is inserted
+// into the second ImGui render pass and never submitted to MAIN.
+extern ImDrawList* g_secondEyeWorldDrawList;
 void DrawBarrelCrosshair();
 void DrawCompactAdsCameraTelemetry();
 extern bool g_showCompactAdsTelemetry;

--- a/include/Render/ColorBlit.hpp
+++ b/include/Render/ColorBlit.hpp
@@ -109,11 +109,9 @@ public:
                             ID3D12Resource* dstColor,
                             const HudParams& params);
 
-    // A filled disc at a point in NDC (-1..1, +Y up), straight-alpha blended over dstColor,
-    // which must be in RENDER_TARGET. Used for the barrel dot in the second eye: eye 0 gets it
-    // from the ImGui overlay drawn into the backbuffer, and the overlay cannot reach eye 1,
-    // which is the VRCAM view. Only the quad's own bounding box is rasterised, so the pass costs
-    // a few hundred pixels rather than a fullscreen draw.
+    // A procedural radial-mesh laser spot at a point in NDC (-1..1, +Y up), straight-alpha
+    // blended over dstColor, which must be in RENDER_TARGET. Retained for the desktop second-eye
+    // mirror; both HMD eyes use the matching ImGui mesh from the overlay path.
     bool RecordDot(ID3D12GraphicsCommandList* cmdList,
                    ID3D12Resource* dstColor,
                    float ndcX, float ndcY,

--- a/include/Stereo/StereoInternal.hpp
+++ b/include/Stereo/StereoInternal.hpp
@@ -489,6 +489,7 @@ extern "C" float    CyberpunkVR_BarrelDotNdcX2;
 extern "C" float    CyberpunkVR_BarrelDotNdcY;
 extern "C" float    CyberpunkVR_BarrelDotRadiusPx;
 extern "C" int      CyberpunkVR_BarrelDotSecondEye;
+extern "C" int      CyberpunkVR_BarrelDotSecondVisible;
 extern "C" unsigned long long CyberpunkVR_BarrelDotTick;
 extern D3D12_CPU_DESCRIPTOR_HANDLE g_own_rtv;
 extern DXGI_FORMAT           g_d12_fmt;

--- a/include/Utils/SharedSlots.hpp
+++ b/include/Utils/SharedSlots.hpp
@@ -83,6 +83,9 @@
 //  [152]      [CAMWRITE] Lua ack (= last [151] applied via SetVRCamAck)  Lua -> dxgi
 //  [153]      [CAMWRITE] entity world yaw (deg)  plugin (SetVRPlayerYaw batch) -> dxgi
 //             (mode-1 heading source: the camera quat can't serve once WE compose it)
+//  [167..169] barrel ray hit world XYZ          plugin (CET push) -> overlay
+//  [170]      barrel ray hit valid              plugin (CET push) -> overlay
+//  [171]      barrel ray packet seqlock         plugin (CET push) -> overlay
 //             ONE-TICK VIEW HOLD protocol (v3, trace-proven mechanism): the entity/
 //             puppet world yaw applies one TICK after the camera turns; sprint locks
 //             puppet yaw to the heading, so the animated body+arms rendered one frame
@@ -206,4 +209,10 @@ constexpr int kWheelArmedMask     = 163;
 constexpr int kDeviceScreenOpen   = 164;
 constexpr int kWheelArmedRightBit = 1;
 constexpr int kWheelArmedLeftBit  = 2;
+// MUZZLE LASER RAYCAST. CET owns the physics query on the script/game thread; the overlay only
+// consumes its world-space hit. [171] brackets XYZ+valid so the render thread cannot combine
+// values from different CET updates. A fresh valid=0 packet deliberately selects direction mode.
+constexpr int kBarrelRayHitX     = 167;   // ..169 world-space hit XYZ
+constexpr int kBarrelRayHitValid = 170;   // 1 = hit, 0 = miss
+constexpr int kBarrelRaySeq      = 171;   // odd while writing, even when coherent
 } // namespace vrshared

--- a/include/Utils/SharedSlots.hpp
+++ b/include/Utils/SharedSlots.hpp
@@ -86,6 +86,11 @@
 //  [167..169] barrel ray hit world XYZ          plugin (CET push) -> overlay
 //  [170]      barrel ray hit valid              plugin (CET push) -> overlay
 //  [171]      barrel ray packet seqlock         plugin (CET push) -> overlay
+//  [172..174] barrel MAIN-eye world XYZ         overlay -> CET
+//  [175..177] barrel second-eye world XYZ       overlay -> CET
+//  [178]      barrel eye-origin packet seqlock  overlay -> CET
+//  [179..180] barrel dot visible MAIN/second    plugin (CET push) -> overlay; bracketed by [171]
+//  [181]      mode-2 laser dot active           overlay -> CET
 //             ONE-TICK VIEW HOLD protocol (v3, trace-proven mechanism): the entity/
 //             puppet world yaw applies one TICK after the camera turns; sprint locks
 //             puppet yaw to the heading, so the animated body+arms rendered one frame
@@ -210,9 +215,19 @@ constexpr int kDeviceScreenOpen   = 164;
 constexpr int kWheelArmedRightBit = 1;
 constexpr int kWheelArmedLeftBit  = 2;
 // MUZZLE LASER RAYCAST. CET owns the physics query on the script/game thread; the overlay only
-// consumes its world-space hit. [171] brackets XYZ+valid so the render thread cannot combine
-// values from different CET updates. A fresh valid=0 packet deliberately selects direction mode.
+// consumes its world-space hit and visibility. [171] brackets XYZ+valid+[179..180] so the render
+// thread cannot combine values from different CET updates. A fresh valid=0 packet deliberately
+// selects direction mode while retaining that update's per-eye visibility.
 constexpr int kBarrelRayHitX     = 167;   // ..169 world-space hit XYZ
 constexpr int kBarrelRayHitValid = 170;   // 1 = hit, 0 = miss
 constexpr int kBarrelRaySeq      = 171;   // odd while writing, even when coherent
+// The eye names follow the two actual draw paths rather than assuming MAIN is always the physical
+// left eye. DrawBarrelCrosshair can swap MAIN's eye sign; publishing MAIN/second keeps visibility
+// attached to the texture that consumes it.
+constexpr int kBarrelMainEyeX       = 172;   // ..174 world-space eye XYZ
+constexpr int kBarrelSecondEyeX     = 175;   // ..177 world-space eye XYZ
+constexpr int kBarrelEyeSeq         = 178;   // odd while writing, even when coherent
+constexpr int kBarrelMainVisible    = 179;   // 1 = clear/fail-open, 0 = occluded
+constexpr int kBarrelSecondVisible  = 180;   // 1 = clear/fail-open, 0 = occluded
+constexpr int kBarrelRayActive      = 181;   // checkbox on + mode 2 + weapon equipped
 } // namespace vrshared

--- a/mods/cet/CyberpunkVRPort_Weapon/init.lua
+++ b/mods/cet/CyberpunkVRPort_Weapon/init.lua
@@ -493,7 +493,25 @@ local function makeBarrelLosEnd(eye, finalHit, fx, fy, fz)
                        eye.z + fz * BARREL_RAY_MAX_M, 1.0)
 end
 
-local function barrelDotVisibleFromEye(player, eye, finalHit, fx, fy, fz)
+-- Keep the exact EntityID selected by the synchronous redscript nearest-hit query. Identity is an
+-- optional side channel only: a getter/marshalling failure must never discard an otherwise valid
+-- NPC surface hit, because XYZ/W keep their existing contract and Ray B must remain usable.
+local function queryNpcBarrelRay(player, rayStart, rayEnd)
+    if not player or not player.VRFindNpcBarrelRayHit then return nil, nil end
+    local hit = player:VRFindNpcBarrelRayHit(rayStart, rayEnd)
+    if not hit or (hit.w or 0.0) <= 0.5 then return hit, nil end
+    if not player.VRGetNpcBarrelRayEntity then return hit, nil end
+
+    local idOk, entityKey = pcall(function()
+        local entityId = player:VRGetNpcBarrelRayEntity()
+        if not entityId then return nil end
+        return tostring(entityId.hash)
+    end)
+    if not idOk then return hit, nil end
+    return hit, entityKey
+end
+
+local function barrelDotVisibleFromEye(player, eye, finalHit, finalNpcKey, fx, fy, fz)
     local rayEnd = makeBarrelLosEnd(eye, finalHit, fx, fy, fz)
     if not rayEnd then return true, 0.0, 'near' end
 
@@ -550,9 +568,8 @@ local function barrelDotVisibleFromEye(player, eye, finalHit, fx, fy, fz)
 
     -- Sight Blocker intentionally ignores character bodies. Only after the world segment is clear
     -- ask the already-validated official HitRepresentation provider whether an NPC blocks it.
-    local npcOk, npcResult = pcall(function()
-        if not player or not player.VRFindNpcBarrelRayHit then return nil end
-        return player:VRFindNpcBarrelRayHit(eye, rayEnd)
+    local npcOk, npcResult, npcEntityKey = pcall(function()
+        return queryNpcBarrelRay(player, eye, rayEnd)
     end)
     if not npcOk then
         if not barrelLosCallWarned then
@@ -563,8 +580,16 @@ local function barrelDotVisibleFromEye(player, eye, finalHit, fx, fy, fz)
         return true, -1.0, 'npc-error'
     end
     if npcResult and (npcResult.w or 0.0) > 0.5 then
-        local dx, dy, dz = npcResult.x - eye.x, npcResult.y - eye.y, npcResult.z - eye.z
-        return false, math.sqrt(dx*dx + dy*dy + dz*dz),
+        local bx, by, bz = npcResult.x - eye.x, npcResult.y - eye.y, npcResult.z - eye.z
+        local blockM = math.sqrt(bx*bx + by*by + bz*bz)
+        -- Once the muzzle ray has selected this NPC as the actual receiving surface, its own
+        -- overlapping HitRepresentation shapes must not make the aiming dot disappear. A
+        -- different NPC still blocks normally, as do the world/vehicle/prop checks above.
+        if finalNpcKey and npcEntityKey and npcEntityKey == finalNpcKey then
+            return true, blockM,
+                glassHits > 0 and ('npc-self-glass' .. tostring(glassHits)) or 'npc-self'
+        end
+        return false, blockM,
             glassHits > 0 and ('npc-glass' .. tostring(glassHits)) or 'npc'
     end
     return true, -1.0, glassHits > 0 and ('clear-glass' .. tostring(glassHits)) or 'clear'
@@ -624,9 +649,8 @@ local function updateBarrelRay(dt)
     -- the closest animated body-surface enter point for each candidate.
     local player = Game.GetPlayer()
     local npcHit, npcDistanceSq = nil, nil
-    local npcOk, npcResult = pcall(function()
-        if not player or not player.VRFindNpcBarrelRayHit then return nil end
-        return player:VRFindNpcBarrelRayHit(from, to)
+    local npcOk, npcResult, npcEntityKey = pcall(function()
+        return queryNpcBarrelRay(player, from, to)
     end)
     if npcOk then
         if npcResult and (npcResult.w or 0.0) > 0.5 and
@@ -644,9 +668,9 @@ local function updateBarrelRay(dt)
         end
     end
 
-    local finalHit, finalDistanceSq = worldHit, worldDistanceSq
+    local finalHit, finalDistanceSq, finalNpcKey = worldHit, worldDistanceSq, nil
     if npcHit and (not finalDistanceSq or npcDistanceSq < finalDistanceSq) then
-        finalHit, finalDistanceSq = npcHit, npcDistanceSq
+        finalHit, finalDistanceSq, finalNpcKey = npcHit, npcDistanceSq, npcEntityKey
     end
 
     local mainVisible, secondVisible = true, true
@@ -655,9 +679,9 @@ local function updateBarrelRay(dt)
     local mainEye, secondEye = readBarrelEyes(dt)
     if player and mainEye and secondEye then
         mainVisible, mainBlockM, mainSource = barrelDotVisibleFromEye(
-            player, mainEye, finalHit, fx, fy, fz)
+            player, mainEye, finalHit, finalNpcKey, fx, fy, fz)
         secondVisible, secondBlockM, secondSource = barrelDotVisibleFromEye(
-            player, secondEye, finalHit, fx, fy, fz)
+            player, secondEye, finalHit, finalNpcKey, fx, fy, fz)
     end
     if vrDebug() then
         local now = (os and os.clock and os.clock()) or 0.0

--- a/mods/cet/CyberpunkVRPort_Weapon/init.lua
+++ b/mods/cet/CyberpunkVRPort_Weapon/init.lua
@@ -414,19 +414,170 @@ end
 -- the physical-reload raycast in this tree. Keep physics out of the DXGI Present path.
 local BARREL_RAY_MAX_M = 1000.0
 local BARREL_RAY_PRESET = 'Sight Blocker'
+local BARREL_LOS_ENDPOINT_OFFSET_M = 0.005
+local BARREL_LOS_GLASS_STEP_M = 0.005
+local BARREL_LOS_MAX_GLASS_HITS = 8
+local BARREL_EYE_MAX_AGE_S = 0.020
 local barrelRaySystem = nil
 local barrelRayCallWarned = false
 local barrelNpcCallWarned = false
+local barrelLosCallWarned = false
+local barrelEyeLastSeq = 0
+local barrelEyeAgeS = math.huge
+local barrelLosLogAt = -1.0
+local barrelRayWasActive = false
 
-local function publishBarrelRayMiss()
+local function publishBarrelRayMiss(mainVisible, secondVisible)
     if type(SetVRBarrelRayHit) == 'function' then
-        SetVRBarrelRayHit(0.0, 0.0, 0.0, 0)
+        SetVRBarrelRayHit(0.0, 0.0, 0.0, 0,
+            mainVisible == false and 0 or 1,
+            secondVisible == false and 0 or 1)
     end
 end
 
-local function updateBarrelRay()
+local function stopBarrelRay()
+    if barrelRayWasActive then
+        publishBarrelRayMiss()
+        barrelRayWasActive = false
+    end
+end
+
+-- Read the two eye origins as one render-side snapshot. A missing or stale packet disables only
+-- occlusion (fail-open); it never disables the existing mode-2 hit provider or direction marker.
+local function readBarrelEyes(dt)
+    barrelEyeAgeS = barrelEyeAgeS + math.max(dt or 0.0, 0.0)
+    for _ = 1, 3 do
+        local s0 = math.floor(GetVRSharedSlot(178) or 0.0)
+        if s0 > 0 and s0 % 2 == 0 then
+            local mx, my, mz = GetVRSharedSlot(172), GetVRSharedSlot(173), GetVRSharedSlot(174)
+            local sx, sy, sz = GetVRSharedSlot(175), GetVRSharedSlot(176), GetVRSharedSlot(177)
+            local s1 = math.floor(GetVRSharedSlot(178) or 0.0)
+            if s0 == s1 and s1 % 2 == 0 then
+                if s1 ~= barrelEyeLastSeq then
+                    barrelEyeLastSeq = s1
+                    barrelEyeAgeS = 0.0
+                end
+                local mainLen2 = mx*mx + my*my + mz*mz
+                local secondLen2 = sx*sx + sy*sy + sz*sz
+                local ex, ey, ez = mx - sx, my - sy, mz - sz
+                local separation2 = ex*ex + ey*ey + ez*ez
+                if barrelEyeAgeS <= BARREL_EYE_MAX_AGE_S and mainLen2 > 1.0 and
+                   secondLen2 > 1.0 and separation2 > 0.0001 and separation2 < 0.04 then
+                    return Vector4.new(mx, my, mz, 1.0), Vector4.new(sx, sy, sz, 1.0)
+                end
+                return nil, nil
+            end
+        end
+    end
+    return nil, nil
+end
+
+local function makeBarrelLosEnd(eye, finalHit, fx, fy, fz)
+    if finalHit then
+        local dx, dy, dz = finalHit.x - eye.x, finalHit.y - eye.y, finalHit.z - eye.z
+        local d2 = dx*dx + dy*dy + dz*dz
+        if d2 <= BARREL_LOS_ENDPOINT_OFFSET_M * BARREL_LOS_ENDPOINT_OFFSET_M then
+            return nil
+        end
+        local invD = 1.0 / math.sqrt(d2)
+        return Vector4.new(
+            finalHit.x - dx * invD * BARREL_LOS_ENDPOINT_OFFSET_M,
+            finalHit.y - dy * invD * BARREL_LOS_ENDPOINT_OFFSET_M,
+            finalHit.z - dz * invD * BARREL_LOS_ENDPOINT_OFFSET_M,
+            1.0)
+    end
+    -- A finite physics segment tests visibility only. The rendered fallback remains optical
+    -- infinity; each eye gets its own parallel segment along the same muzzle direction.
+    return Vector4.new(eye.x + fx * BARREL_RAY_MAX_M,
+                       eye.y + fy * BARREL_RAY_MAX_M,
+                       eye.z + fz * BARREL_RAY_MAX_M, 1.0)
+end
+
+local function barrelDotVisibleFromEye(player, eye, finalHit, fx, fy, fz)
+    local rayEnd = makeBarrelLosEnd(eye, finalHit, fx, fy, fz)
+    if not rayEnd then return true, 0.0, 'near' end
+
+    -- Use the same world collision semantics already validated by the muzzle provider. The first
+    -- probe's generic QueryFilter missed vehicles and added no proven coverage. Glass materials are
+    -- transparent to the dot LOS: step through each glass hit on the same segment rather than
+    -- declaring the whole remaining segment clear and missing an opaque blocker behind the pane.
+    local dx, dy, dz = rayEnd.x - eye.x, rayEnd.y - eye.y, rayEnd.z - eye.z
+    local rayLengthSq = dx*dx + dy*dy + dz*dz
+    if rayLengthSq <= 0.000001 then return true, 0.0, 'near' end
+    local invRayLength = 1.0 / math.sqrt(rayLengthSq)
+    local dirX, dirY, dirZ = dx * invRayLength, dy * invRayLength, dz * invRayLength
+    local worldStart = eye
+    local glassHits = 0
+    for _ = 1, BARREL_LOS_MAX_GLASS_HITS + 1 do
+        local worldOk, worldSuccess, worldResult = pcall(function()
+            return barrelRaySystem:SyncRaycastByQueryPreset(
+                worldStart, rayEnd, BARREL_RAY_PRESET, false)
+        end)
+        if not worldOk then
+            if not barrelLosCallWarned then
+                barrelLosCallWarned = true
+                logAlways('barrel world LOS failed; visibility remains fail-open: %s',
+                    tostring(worldSuccess))
+            end
+            return true, -1.0, 'world-error'
+        end
+        if not (worldSuccess and worldResult and worldResult.position) then
+            break
+        end
+
+        local p = worldResult.position
+        local materialName = string.lower(tostring(worldResult.material or ''))
+        if not string.find(materialName, 'glass', 1, true) then
+            local bx, by, bz = p.x - eye.x, p.y - eye.y, p.z - eye.z
+            return false, math.sqrt(bx*bx + by*by + bz*bz), 'world'
+        end
+
+        glassHits = glassHits + 1
+        if glassHits > BARREL_LOS_MAX_GLASS_HITS then
+            break
+        end
+        worldStart = Vector4.new(
+            p.x + dirX * BARREL_LOS_GLASS_STEP_M,
+            p.y + dirY * BARREL_LOS_GLASS_STEP_M,
+            p.z + dirZ * BARREL_LOS_GLASS_STEP_M,
+            1.0)
+        local rx, ry, rz = rayEnd.x - worldStart.x, rayEnd.y - worldStart.y,
+                           rayEnd.z - worldStart.z
+        if rx*dirX + ry*dirY + rz*dirZ <= 0.0 then
+            break
+        end
+    end
+
+    -- Sight Blocker intentionally ignores character bodies. Only after the world segment is clear
+    -- ask the already-validated official HitRepresentation provider whether an NPC blocks it.
+    local npcOk, npcResult = pcall(function()
+        if not player or not player.VRFindNpcBarrelRayHit then return nil end
+        return player:VRFindNpcBarrelRayHit(eye, rayEnd)
+    end)
+    if not npcOk then
+        if not barrelLosCallWarned then
+            barrelLosCallWarned = true
+            logAlways('barrel NPC LOS failed; visibility remains fail-open: %s',
+                tostring(npcResult))
+        end
+        return true, -1.0, 'npc-error'
+    end
+    if npcResult and (npcResult.w or 0.0) > 0.5 then
+        local dx, dy, dz = npcResult.x - eye.x, npcResult.y - eye.y, npcResult.z - eye.z
+        return false, math.sqrt(dx*dx + dy*dy + dz*dz),
+            glassHits > 0 and ('npc-glass' .. tostring(glassHits)) or 'npc'
+    end
+    return true, -1.0, glassHits > 0 and ('clear-glass' .. tostring(glassHits)) or 'clear'
+end
+
+local function updateBarrelRay(dt)
     if type(GetVRSharedSlot) ~= 'function' then return end
     if type(SetVRBarrelRayHit) ~= 'function' then return end
+    if GetVRSharedSlot(181) < 0.5 then
+        stopBarrelRay()
+        return
+    end
+    barrelRayWasActive = true
     if GetVRSharedSlot(27) < 0.5 or GetVRSharedSlot(203) < 0.5 then
         publishBarrelRayMiss()
         return
@@ -471,9 +622,9 @@ local function updateBarrelRay()
     -- Ray B uses the exact same from/to and has no cross-frame cache: W=0 is an immediate miss.
     -- Targeting supplies and deduplicates candidates in redscript; native HitRepresentation gives
     -- the closest animated body-surface enter point for each candidate.
+    local player = Game.GetPlayer()
     local npcHit, npcDistanceSq = nil, nil
     local npcOk, npcResult = pcall(function()
-        local player = Game.GetPlayer()
         if not player or not player.VRFindNpcBarrelRayHit then return nil end
         return player:VRFindNpcBarrelRayHit(from, to)
     end)
@@ -497,12 +648,35 @@ local function updateBarrelRay()
     if npcHit and (not finalDistanceSq or npcDistanceSq < finalDistanceSq) then
         finalHit, finalDistanceSq = npcHit, npcDistanceSq
     end
+
+    local mainVisible, secondVisible = true, true
+    local mainBlockM, secondBlockM = -1.0, -1.0
+    local mainSource, secondSource = 'no-eyes', 'no-eyes'
+    local mainEye, secondEye = readBarrelEyes(dt)
+    if player and mainEye and secondEye then
+        mainVisible, mainBlockM, mainSource = barrelDotVisibleFromEye(
+            player, mainEye, finalHit, fx, fy, fz)
+        secondVisible, secondBlockM, secondSource = barrelDotVisibleFromEye(
+            player, secondEye, finalHit, fx, fy, fz)
+    end
+    if vrDebug() then
+        local now = (os and os.clock and os.clock()) or 0.0
+        if now - barrelLosLogAt >= 1.0 then
+            barrelLosLogAt = now
+            logAlways('barrel LOS: eyes=%d hit=%d main=%s/%s block=%.3fm second=%s/%s block=%.3fm',
+                (mainEye and secondEye) and 1 or 0,
+                finalHit and 1 or 0,
+                mainVisible and 'clear' or 'blocked', mainSource, mainBlockM,
+                secondVisible and 'clear' or 'blocked', secondSource, secondBlockM)
+        end
+    end
     if finalHit then
-        SetVRBarrelRayHit(finalHit.x, finalHit.y, finalHit.z, 1)
+        SetVRBarrelRayHit(finalHit.x, finalHit.y, finalHit.z, 1,
+            mainVisible and 1 or 0, secondVisible and 1 or 0)
         return
     end
 
-    publishBarrelRayMiss()
+    publishBarrelRayMiss(mainVisible, secondVisible)
 end
 
 registerForEvent('onInit', function()
@@ -543,7 +717,7 @@ registerForEvent('onUpdate', function(dt)
         -- newcomer gets its own pcall.
         if wpn then updateMuzzle(wpn) end
         local okRay, errRay = pcall(function()
-            if wpn then updateBarrelRay() else publishBarrelRayMiss() end
+            if wpn then updateBarrelRay(dt) else stopBarrelRay() end
         end)
         if not okRay then
             publishBarrelRayMiss()

--- a/mods/cet/CyberpunkVRPort_Weapon/init.lua
+++ b/mods/cet/CyberpunkVRPort_Weapon/init.lua
@@ -409,6 +409,102 @@ local function updateMuzzle(wpn)
     end
 end
 
+-- Trace the weapon's bore against world collision on CET's game-script side. The current
+-- CET/CP2077 build exposes the hit as TraceResult.position; this same contract is already used by
+-- the physical-reload raycast in this tree. Keep physics out of the DXGI Present path.
+local BARREL_RAY_MAX_M = 1000.0
+local BARREL_RAY_PRESET = 'Sight Blocker'
+local barrelRaySystem = nil
+local barrelRayCallWarned = false
+local barrelNpcCallWarned = false
+
+local function publishBarrelRayMiss()
+    if type(SetVRBarrelRayHit) == 'function' then
+        SetVRBarrelRayHit(0.0, 0.0, 0.0, 0)
+    end
+end
+
+local function updateBarrelRay()
+    if type(GetVRSharedSlot) ~= 'function' then return end
+    if type(SetVRBarrelRayHit) ~= 'function' then return end
+    if GetVRSharedSlot(27) < 0.5 or GetVRSharedSlot(203) < 0.5 then
+        publishBarrelRayMiss()
+        return
+    end
+
+    local px, py, pz = GetVRSharedSlot(200), GetVRSharedSlot(201), GetVRSharedSlot(202)
+    local fx, fy, fz = GetVRSharedSlot(24), GetVRSharedSlot(25), GetVRSharedSlot(26)
+    local f2 = fx * fx + fy * fy + fz * fz
+    if px * px + py * py + pz * pz < 1.0 or f2 < 0.25 then
+        publishBarrelRayMiss()
+        return
+    end
+
+    local invF = 1.0 / math.sqrt(f2)
+    fx, fy, fz = fx * invF, fy * invF, fz * invF
+    local from = Vector4.new(px, py, pz, 1.0)
+    local to = Vector4.new(px + fx * BARREL_RAY_MAX_M,
+                           py + fy * BARREL_RAY_MAX_M,
+                           pz + fz * BARREL_RAY_MAX_M, 1.0)
+    if barrelRaySystem == nil then
+        barrelRaySystem = Game.GetSpatialQueriesSystem() or false
+    end
+    if not barrelRaySystem then
+        publishBarrelRayMiss()
+        return
+    end
+
+    -- Sight Blocker with dynamic collision covers world, props, vehicles and glass without
+    -- self-hitting the tested player hands or weapons. NPC body surfaces use Ray B below.
+    local worldHit, worldDistanceSq = nil, nil
+    local success, result = barrelRaySystem:SyncRaycastByQueryPreset(
+        from, to, BARREL_RAY_PRESET, false)
+    if success and result then
+        local p = result.position
+        if p and type(p.x) == 'number' and type(p.y) == 'number' and type(p.z) == 'number' then
+            local dx, dy, dz = p.x - px, p.y - py, p.z - pz
+            worldHit = p
+            worldDistanceSq = dx * dx + dy * dy + dz * dz
+        end
+    end
+
+    -- Ray B uses the exact same from/to and has no cross-frame cache: W=0 is an immediate miss.
+    -- Targeting supplies and deduplicates candidates in redscript; native HitRepresentation gives
+    -- the closest animated body-surface enter point for each candidate.
+    local npcHit, npcDistanceSq = nil, nil
+    local npcOk, npcResult = pcall(function()
+        local player = Game.GetPlayer()
+        if not player or not player.VRFindNpcBarrelRayHit then return nil end
+        return player:VRFindNpcBarrelRayHit(from, to)
+    end)
+    if npcOk then
+        if npcResult and (npcResult.w or 0.0) > 0.5 and
+           type(npcResult.x) == 'number' and type(npcResult.y) == 'number' and
+           type(npcResult.z) == 'number' then
+            local dx, dy, dz = npcResult.x - px, npcResult.y - py, npcResult.z - pz
+            npcHit = npcResult
+            npcDistanceSq = dx * dx + dy * dy + dz * dz
+        end
+    else
+        if not barrelNpcCallWarned then
+            barrelNpcCallWarned = true
+            logAlways('barrel ray: NPC surface query failed; Ray A remains active: %s',
+                tostring(npcResult))
+        end
+    end
+
+    local finalHit, finalDistanceSq = worldHit, worldDistanceSq
+    if npcHit and (not finalDistanceSq or npcDistanceSq < finalDistanceSq) then
+        finalHit, finalDistanceSq = npcHit, npcDistanceSq
+    end
+    if finalHit then
+        SetVRBarrelRayHit(finalHit.x, finalHit.y, finalHit.z, 1)
+        return
+    end
+
+    publishBarrelRayMiss()
+end
+
 registerForEvent('onInit', function()
     logf("weapon-aim init")
 end)
@@ -446,6 +542,16 @@ registerForEvent('onUpdate', function(dt)
         -- immediately. Isolation belongs in the OTHER direction: the muzzle keeps its place and the
         -- newcomer gets its own pcall.
         if wpn then updateMuzzle(wpn) end
+        local okRay, errRay = pcall(function()
+            if wpn then updateBarrelRay() else publishBarrelRayMiss() end
+        end)
+        if not okRay then
+            publishBarrelRayMiss()
+            if not barrelRayCallWarned then
+                barrelRayCallWarned = true
+                logAlways('barrel ray: query failed: %s', tostring(errRay))
+            end
+        end
         if wpn then
             local wid = nil
             pcall(function() wid = tostring(wpn:GetEntityID().hash) end)

--- a/mods/redscript/CyberpunkVRPort_Melee/vrport_npc_ray_natives.reds
+++ b/mods/redscript/CyberpunkVRPort_Melee/vrport_npc_ray_natives.reds
@@ -1,0 +1,64 @@
+// CyberpunkVRPort -- global native declaration for the NPC hit-representation surface query.
+//
+// This file intentionally has no module declaration. The plugin registers a plain global
+// QueryVRNpcHitSurface; declaring it inside CyberpunkVRPort.Melee would make redscript look for a
+// module-qualified native that does not exist.
+
+native func QueryVRNpcHitSurface(entity: ref<GameObject>, from: Vector4, to: Vector4) -> Vector4;
+
+// Find the closest NPC body surface on the current muzzle ray. Targeting only supplies nearby
+// candidates; the native query intersects each unique entity's live animated HitRepresentation.
+@addMethod(PlayerPuppet)
+public func VRFindNpcBarrelRayHit(rayStart: Vector4, rayEnd: Vector4) -> Vector4 {
+  let q: TargetSearchQuery;
+  q.testedSet = TargetingSet.Complete;
+  q.searchFilter = TSF_NPC();
+  q.maxDistance = 60.0;
+  q.filterObjectByDistance = true;
+  q.ignoreInstigator = true;
+  let parts: array<TS_TargetPartInfo>;
+  GameInstance.GetTargetingSystem(this.GetGame()).GetTargetParts(this, q, parts);
+
+  let seen: array<EntityID>;
+  let best = new Vector4(0.0, 0.0, 0.0, 0.0);
+  let bestDistanceSq = 999999999.0;
+  let i = 0;
+  while i < ArraySize(parts) {
+    let comp = TS_TargetPartInfo.GetComponent(parts[i]);
+    if IsDefined(comp) {
+      let ent = comp.GetEntity() as GameObject;
+      if IsDefined(ent) {
+        let entityId = ent.GetEntityID();
+        let duplicate = false;
+        let j = 0;
+        while j < ArraySize(seen) {
+          if seen[j] == entityId { duplicate = true; };
+          j += 1;
+        };
+        if !duplicate {
+          ArrayPush(seen, entityId);
+          let hit = QueryVRNpcHitSurface(ent, rayStart, rayEnd);
+          if hit.W > 0.5 {
+            let dx = hit.X - rayStart.X;
+            let dy = hit.Y - rayStart.Y;
+            let dz = hit.Z - rayStart.Z;
+            let distanceSq = dx*dx + dy*dy + dz*dz;
+            if distanceSq < bestDistanceSq {
+              bestDistanceSq = distanceSq;
+              best = hit;
+            };
+          };
+        };
+      };
+    };
+    i += 1;
+  };
+  if best.W < 0.5 {
+    if ArraySize(parts) == 0 {
+      best.W = -1.0; // TargetingSystem returned no NPC target parts.
+    } else {
+      best.W = -3.0; // Unique NPC candidates existed, but no body surface intersected.
+    };
+  };
+  return best;
+}

--- a/mods/redscript/CyberpunkVRPort_Melee/vrport_npc_ray_natives.reds
+++ b/mods/redscript/CyberpunkVRPort_Melee/vrport_npc_ray_natives.reds
@@ -6,6 +6,14 @@
 
 native func QueryVRNpcHitSurface(entity: ref<GameObject>, from: Vector4, to: Vector4) -> Vector4;
 
+// Exact identity of the winner selected by the most recent VRFindNpcBarrelRayHit call.
+// CET reads it immediately after the synchronous query so the final NPC target can be
+// distinguished from a different NPC that genuinely blocks the eye-to-dot LOS.
+@addField(PlayerPuppet) let m_vrNpcBarrelRayEntity: EntityID;
+
+@addMethod(PlayerPuppet)
+public func VRGetNpcBarrelRayEntity() -> EntityID { return this.m_vrNpcBarrelRayEntity; }
+
 // Find the closest NPC body surface on the current muzzle ray. Targeting only supplies nearby
 // candidates; the native query intersects each unique entity's live animated HitRepresentation.
 @addMethod(PlayerPuppet)
@@ -21,6 +29,7 @@ public func VRFindNpcBarrelRayHit(rayStart: Vector4, rayEnd: Vector4) -> Vector4
 
   let seen: array<EntityID>;
   let best = new Vector4(0.0, 0.0, 0.0, 0.0);
+  let bestEntity: EntityID;
   let bestDistanceSq = 999999999.0;
   let i = 0;
   while i < ArraySize(parts) {
@@ -46,6 +55,7 @@ public func VRFindNpcBarrelRayHit(rayStart: Vector4, rayEnd: Vector4) -> Vector4
             if distanceSq < bestDistanceSq {
               bestDistanceSq = distanceSq;
               best = hit;
+              bestEntity = entityId;
             };
           };
         };
@@ -53,6 +63,7 @@ public func VRFindNpcBarrelRayHit(rayStart: Vector4, rayEnd: Vector4) -> Vector4
     };
     i += 1;
   };
+  this.m_vrNpcBarrelRayEntity = bestEntity;
   if best.W < 0.5 {
     if ArraySize(parts) == 0 {
       best.W = -1.0; // TargetingSystem returned no NPC target parts.

--- a/src/Core/LauncherConfig.cpp
+++ b/src/Core/LauncherConfig.cpp
@@ -182,6 +182,7 @@ void EnsureLiveControlFileExists() {
     fprintf(file, "xr_snap_turn=0\n");
     fprintf(file, "xr_snap_turn_angle_deg=30\n");
     fprintf(file, "xr_movement_source=0\n");
+    fprintf(file, "xr_laser_dot_mode=1\n");
     // Default ON for the gameplay-input pipeline: both flags are required for the
     // VR controller to reach CP2077 as an XInput pad (otherwise the game detects no
     // controller and shows keyboard glyphs). Set either to 0 in vrport.ini if a
@@ -246,4 +247,3 @@ void SaveLauncherConfig(int width, int height) {
     fprintf(file, "debug=%d\n", g_launcherDebug);
     fclose(file);
 }
-

--- a/src/Core/LauncherConfig.cpp
+++ b/src/Core/LauncherConfig.cpp
@@ -183,6 +183,8 @@ void EnsureLiveControlFileExists() {
     fprintf(file, "xr_snap_turn_angle_deg=30\n");
     fprintf(file, "xr_movement_source=0\n");
     fprintf(file, "xr_laser_dot_mode=1\n");
+    fprintf(file, "xr_laser_dot_radius_mm=6\n");
+    fprintf(file, "xr_laser_dot_scale_with_distance=0\n");
     // Default ON for the gameplay-input pipeline: both flags are required for the
     // VR controller to reach CP2077 as an XInput pad (otherwise the game detects no
     // controller and shows keyboard glyphs). Set either to 0 in vrport.ini if a

--- a/src/Core/LiveControlsPoll.cpp
+++ b/src/Core/LiveControlsPoll.cpp
@@ -220,6 +220,7 @@ void PollLiveControls() {
     };
     float xrSnapTurnAngleDeg = g_liveControls.xrSnapTurnAngleDeg > 0.0f ? g_liveControls.xrSnapTurnAngleDeg : 30.0f;
     int xrMovementSource = g_liveControls.xrMovementSource;
+    int xrLaserDotMode = g_liveControls.xrLaserDotMode;
     int xrXInputInstall = g_liveControls.xrXInputInstall;
     int xrInputActions = g_liveControls.xrInputActions;
     int xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
@@ -478,6 +479,11 @@ void PollLiveControls() {
             xrMovementSource = intValue;
             continue;
         }
+        if (sscanf_s(line, "xr_laser_dot_mode=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_laser_dot_mode = %d", &intValue) == 1) {
+            xrLaserDotMode = intValue;
+            continue;
+        }
         if (sscanf_s(line, "xr_cutscene_suspend_tier=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_cutscene_suspend_tier = %d", &intValue) == 1) {
             xrCutsceneSuspendTier = intValue;
@@ -635,6 +641,7 @@ void PollLiveControls() {
     // means VR-driven so map to legacy 1).
     if (xrMovementSource < 0 || xrMovementSource > 3) xrMovementSource = xrMovementControl != 0 ? 1 : 0;
     g_liveControls.xrMovementSource = xrMovementSource;
+    g_liveControls.xrLaserDotMode = (xrLaserDotMode < 0) ? 0 : (xrLaserDotMode > 2 ? 2 : xrLaserDotMode);
     g_liveControls.xrMovementControl = xrMovementSource != 0 ? 1 : 0;
     g_liveControls.xrPhysicalBodyRotation = xrPhysicalBodyRotation != 0 ? 1 : 0;
     g_liveControls.xrCutsceneSuspendTier =
@@ -771,6 +778,7 @@ LiveControlsUiState MakeLiveControlsUiState() {
     state.xrSnapTurn = g_liveControls.xrSnapTurn;
     state.xrSnapTurnAngleDeg = g_liveControls.xrSnapTurnAngleDeg;
     state.xrMovementSource = g_liveControls.xrMovementSource;
+    state.xrLaserDotMode = g_liveControls.xrLaserDotMode;
     state.xrPhysicalBodyRotation = g_liveControls.xrPhysicalBodyRotation;
     state.xrCutsceneSuspendTier = g_liveControls.xrCutsceneSuspendTier;
     state.xrXInputInstall = g_liveControls.xrXInputInstall;
@@ -855,6 +863,7 @@ void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_snap_turn=%d\n", state.xrSnapTurn != 0 ? 1 : 0);
     fprintf(file, "xr_snap_turn_angle_deg=%.2f\n", state.xrSnapTurnAngleDeg > 0.0f ? state.xrSnapTurnAngleDeg : 30.0f);
     fprintf(file, "xr_movement_source=%d\n", state.xrMovementSource < 0 ? 0 : (state.xrMovementSource > 3 ? 3 : state.xrMovementSource));
+    fprintf(file, "xr_laser_dot_mode=%d\n", state.xrLaserDotMode < 0 ? 0 : (state.xrLaserDotMode > 2 ? 2 : state.xrLaserDotMode));
     fprintf(file, "xr_physical_body_rotation=%d\n", state.xrPhysicalBodyRotation != 0 ? 1 : 0);
     fprintf(file, "xr_cutscene_suspend_tier=%d\n",
             state.xrCutsceneSuspendTier < -1 ? -1 : (state.xrCutsceneSuspendTier > 4 ? 4 : state.xrCutsceneSuspendTier));
@@ -927,6 +936,8 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
         g_liveControls.xrMovementSource = src;
         g_liveControls.xrMovementControl = src != 0 ? 1 : 0;
     }
+    g_liveControls.xrLaserDotMode =
+        (state->xrLaserDotMode < 0) ? 0 : (state->xrLaserDotMode > 2 ? 2 : state->xrLaserDotMode);
     g_liveControls.xrPhysicalBodyRotation = state->xrPhysicalBodyRotation != 0 ? 1 : 0;
     g_liveControls.xrCutsceneSuspendTier =
         (state->xrCutsceneSuspendTier < -1) ? -1

--- a/src/Core/LiveControlsPoll.cpp
+++ b/src/Core/LiveControlsPoll.cpp
@@ -221,6 +221,8 @@ void PollLiveControls() {
     float xrSnapTurnAngleDeg = g_liveControls.xrSnapTurnAngleDeg > 0.0f ? g_liveControls.xrSnapTurnAngleDeg : 30.0f;
     int xrMovementSource = g_liveControls.xrMovementSource;
     int xrLaserDotMode = g_liveControls.xrLaserDotMode;
+    float xrLaserDotRadiusMm = g_liveControls.xrLaserDotRadiusMm > 0.0f ? g_liveControls.xrLaserDotRadiusMm : 6.0f;
+    int xrLaserDotScaleWithDistance = g_liveControls.xrLaserDotScaleWithDistance;
     int xrXInputInstall = g_liveControls.xrXInputInstall;
     int xrInputActions = g_liveControls.xrInputActions;
     int xrMonoXQueueWait = g_liveControls.xrMonoXQueueWait;
@@ -484,6 +486,16 @@ void PollLiveControls() {
             xrLaserDotMode = intValue;
             continue;
         }
+        if (sscanf_s(line, "xr_laser_dot_radius_mm=%f", &value) == 1 ||
+            sscanf_s(line, "xr_laser_dot_radius_mm = %f", &value) == 1) {
+            xrLaserDotRadiusMm = value;
+            continue;
+        }
+        if (sscanf_s(line, "xr_laser_dot_scale_with_distance=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_laser_dot_scale_with_distance = %d", &intValue) == 1) {
+            xrLaserDotScaleWithDistance = intValue;
+            continue;
+        }
         if (sscanf_s(line, "xr_cutscene_suspend_tier=%d", &intValue) == 1 ||
             sscanf_s(line, "xr_cutscene_suspend_tier = %d", &intValue) == 1) {
             xrCutsceneSuspendTier = intValue;
@@ -642,6 +654,9 @@ void PollLiveControls() {
     if (xrMovementSource < 0 || xrMovementSource > 3) xrMovementSource = xrMovementControl != 0 ? 1 : 0;
     g_liveControls.xrMovementSource = xrMovementSource;
     g_liveControls.xrLaserDotMode = (xrLaserDotMode < 0) ? 0 : (xrLaserDotMode > 2 ? 2 : xrLaserDotMode);
+    g_liveControls.xrLaserDotRadiusMm =
+        xrLaserDotRadiusMm < 1.0f ? 1.0f : (xrLaserDotRadiusMm > 50.0f ? 50.0f : xrLaserDotRadiusMm);
+    g_liveControls.xrLaserDotScaleWithDistance = xrLaserDotScaleWithDistance != 0 ? 1 : 0;
     g_liveControls.xrMovementControl = xrMovementSource != 0 ? 1 : 0;
     g_liveControls.xrPhysicalBodyRotation = xrPhysicalBodyRotation != 0 ? 1 : 0;
     g_liveControls.xrCutsceneSuspendTier =
@@ -779,6 +794,8 @@ LiveControlsUiState MakeLiveControlsUiState() {
     state.xrSnapTurnAngleDeg = g_liveControls.xrSnapTurnAngleDeg;
     state.xrMovementSource = g_liveControls.xrMovementSource;
     state.xrLaserDotMode = g_liveControls.xrLaserDotMode;
+    state.xrLaserDotRadiusMm = g_liveControls.xrLaserDotRadiusMm;
+    state.xrLaserDotScaleWithDistance = g_liveControls.xrLaserDotScaleWithDistance;
     state.xrPhysicalBodyRotation = g_liveControls.xrPhysicalBodyRotation;
     state.xrCutsceneSuspendTier = g_liveControls.xrCutsceneSuspendTier;
     state.xrXInputInstall = g_liveControls.xrXInputInstall;
@@ -864,6 +881,9 @@ void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_snap_turn_angle_deg=%.2f\n", state.xrSnapTurnAngleDeg > 0.0f ? state.xrSnapTurnAngleDeg : 30.0f);
     fprintf(file, "xr_movement_source=%d\n", state.xrMovementSource < 0 ? 0 : (state.xrMovementSource > 3 ? 3 : state.xrMovementSource));
     fprintf(file, "xr_laser_dot_mode=%d\n", state.xrLaserDotMode < 0 ? 0 : (state.xrLaserDotMode > 2 ? 2 : state.xrLaserDotMode));
+    fprintf(file, "xr_laser_dot_radius_mm=%.0f\n",
+            state.xrLaserDotRadiusMm < 1.0f ? 1.0f : (state.xrLaserDotRadiusMm > 50.0f ? 50.0f : state.xrLaserDotRadiusMm));
+    fprintf(file, "xr_laser_dot_scale_with_distance=%d\n", state.xrLaserDotScaleWithDistance != 0 ? 1 : 0);
     fprintf(file, "xr_physical_body_rotation=%d\n", state.xrPhysicalBodyRotation != 0 ? 1 : 0);
     fprintf(file, "xr_cutscene_suspend_tier=%d\n",
             state.xrCutsceneSuspendTier < -1 ? -1 : (state.xrCutsceneSuspendTier > 4 ? 4 : state.xrCutsceneSuspendTier));
@@ -938,6 +958,10 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
     }
     g_liveControls.xrLaserDotMode =
         (state->xrLaserDotMode < 0) ? 0 : (state->xrLaserDotMode > 2 ? 2 : state->xrLaserDotMode);
+    g_liveControls.xrLaserDotRadiusMm =
+        state->xrLaserDotRadiusMm < 1.0f ? 1.0f
+                                        : (state->xrLaserDotRadiusMm > 50.0f ? 50.0f : state->xrLaserDotRadiusMm);
+    g_liveControls.xrLaserDotScaleWithDistance = state->xrLaserDotScaleWithDistance != 0 ? 1 : 0;
     g_liveControls.xrPhysicalBodyRotation = state->xrPhysicalBodyRotation != 0 ? 1 : 0;
     g_liveControls.xrCutsceneSuspendTier =
         (state->xrCutsceneSuspendTier < -1) ? -1

--- a/src/Natives/OrientationProvider.cpp
+++ b/src/Natives/OrientationProvider.cpp
@@ -664,14 +664,18 @@ void SetVRMuzzleQuat(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*,
 }
 
 // Publish CET's muzzle raycast result without performing a game-world query from Present. The
-// sequence brackets four independent float stores so the render thread only consumes one update.
+// sequence brackets the hit and per-eye visibility stores so the render thread consumes one update.
 void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t) {
     float x = 0.0f, y = 0.0f, z = 0.0f;
     int32_t valid = 0;
+    int32_t mainVisible = 1;
+    int32_t secondVisible = 1;
     RED4ext::GetParameter(aFrame, &x);
     RED4ext::GetParameter(aFrame, &y);
     RED4ext::GetParameter(aFrame, &z);
     RED4ext::GetParameter(aFrame, &valid);
+    RED4ext::GetParameter(aFrame, &mainVisible);
+    RED4ext::GetParameter(aFrame, &secondVisible);
     aFrame->code++;
     EnsureSharedMemory();
     if (!g_pSharedHands) return;
@@ -687,6 +691,8 @@ void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void
     g_pSharedHands[vrshared::kBarrelRayHitX + 1] = y;
     g_pSharedHands[vrshared::kBarrelRayHitX + 2] = z;
     g_pSharedHands[vrshared::kBarrelRayHitValid] = valid != 0 ? 1.0f : 0.0f;
+    g_pSharedHands[vrshared::kBarrelMainVisible] = mainVisible != 0 ? 1.0f : 0.0f;
+    g_pSharedHands[vrshared::kBarrelSecondVisible] = secondVisible != 0 ? 1.0f : 0.0f;
     std::atomic_thread_fence(std::memory_order_release);
     g_pSharedHands[vrshared::kBarrelRaySeq] = static_cast<float>(nextEven);
     s_evenSeq = nextEven;
@@ -1035,4 +1041,3 @@ void ResetVRProvCounts(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void
     g_provOverrides = 0;
     for (int i = 0; i < 4; ++i) { g_provLastQ[i]=0; g_provOrigQ[i]=0; g_provCtrlQ[i]=0; g_provHmdQ[i]=0; }
 }
-

--- a/src/Natives/OrientationProvider.cpp
+++ b/src/Natives/OrientationProvider.cpp
@@ -5,6 +5,7 @@
 // register rather than guessing what passes through it.
 #include <RED4ext/RED4ext.hpp>
 #include <RED4ext/GameEngine.hpp>
+#include <atomic>
 #include <sstream>
 #include <locale>
 #include <clocale>
@@ -48,15 +49,19 @@
 #include <RED4ext/Scripting/Natives/entAnimationControllerComponent.hpp>
 #include <RED4ext/Scripting/Natives/Generated/ent/GarmentSkinnedMeshComponent.hpp>
 #include <RED4ext/Scripting/Natives/Generated/ent/MeshComponent.hpp>
+#include <RED4ext/Scripting/Natives/Generated/game/HitRepresentationComponent.hpp>
+#include <RED4ext/Scripting/Natives/Generated/game/HitShapeUserData.hpp>
+#include <RED4ext/Scripting/Natives/Generated/game/QueryResult.hpp>
 #include <windows.h>
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstring>
-#include <atomic>
 #include <cstdint>
 #include <fstream>
 #include <utility>
 #include <iomanip>
+#include <limits>
 #include <string>
 #include "Anim/VrikHook.hpp"
 #include "Anim/WeaponAim.hpp"
@@ -66,8 +71,6 @@
 #include "Natives/NativeFunctions.hpp"
 #include "Natives/NativeHelpers.hpp"
 #include "Natives/NativeState.hpp"
-
-
 
 // ============================================================================
 // ORIENTATION-PROVIDER GetOrientation VMT INSTRUMENT (the user's "stand at the register" plan).
@@ -659,6 +662,144 @@ void SetVRMuzzleQuat(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*,
         g_pSharedHands[27] = 1.0f;  // valid
     }
 }
+
+// Publish CET's muzzle raycast result without performing a game-world query from Present. The
+// sequence brackets four independent float stores so the render thread only consumes one update.
+void SetVRBarrelRayHit(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, int64_t) {
+    float x = 0.0f, y = 0.0f, z = 0.0f;
+    int32_t valid = 0;
+    RED4ext::GetParameter(aFrame, &x);
+    RED4ext::GetParameter(aFrame, &y);
+    RED4ext::GetParameter(aFrame, &z);
+    RED4ext::GetParameter(aFrame, &valid);
+    aFrame->code++;
+    EnsureSharedMemory();
+    if (!g_pSharedHands) return;
+
+    // Float retains exact integer values in this range. Bounding the counter keeps long sessions
+    // away from the 24-bit precision limit used by the shared-memory transport.
+    static uint32_t s_evenSeq = 0;
+    uint32_t nextEven = s_evenSeq + 2u;
+    if (nextEven >= 1000000u) nextEven = 2u;
+    g_pSharedHands[vrshared::kBarrelRaySeq] = static_cast<float>(nextEven - 1u);
+    std::atomic_thread_fence(std::memory_order_release);
+    g_pSharedHands[vrshared::kBarrelRayHitX + 0] = x;
+    g_pSharedHands[vrshared::kBarrelRayHitX + 1] = y;
+    g_pSharedHands[vrshared::kBarrelRayHitX + 2] = z;
+    g_pSharedHands[vrshared::kBarrelRayHitValid] = valid != 0 ? 1.0f : 0.0f;
+    std::atomic_thread_fence(std::memory_order_release);
+    g_pSharedHands[vrshared::kBarrelRaySeq] = static_cast<float>(nextEven);
+    s_evenSeq = nextEven;
+}
+
+struct HitRepQueryState {
+    alignas(16) RED4ext::game::QueryResult result{};
+    int32_t status = 0;
+    bool initialized = false;
+};
+
+static bool HitRepMatchesBytes(const uint8_t* aAddress, const uint8_t* aExpected, size_t aCount) {
+    __try {
+        if (!aAddress || !aExpected) return false;
+        for (size_t i = 0; i < aCount; ++i) {
+            if (aAddress[i] != aExpected[i]) return false;
+        }
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+static void QueryHitRepSurfaceNative(RED4ext::game::HitRepresentationComponent* aComponent,
+                                     const RED4ext::Vector4* aFrom,
+                                     const RED4ext::Vector4* aTo,
+                                     HitRepQueryState* aState) {
+    if (!aComponent || !aFrom || !aTo || !aState) return;
+    __try {
+        const uintptr_t base = reinterpret_cast<uintptr_t>(GetModuleHandleW(L"Cyberpunk2077.exe"));
+        if (!base) { aState->status = -1; return; }
+        static constexpr uint8_t kQueryBytes[] = {0x48, 0x8B, 0xC4, 0x53};
+        static constexpr uint8_t kResultCtorBytes[] = {0x83, 0x61, 0x08, 0x00};
+        if (!HitRepMatchesBytes(reinterpret_cast<const uint8_t*>(base + 0x8BB428),
+                kQueryBytes, sizeof(kQueryBytes)) ||
+            !HitRepMatchesBytes(reinterpret_cast<const uint8_t*>(base + 0x8BA038),
+                kResultCtorBytes, sizeof(kResultCtorBytes))) {
+            aState->status = -3;
+            return;
+        }
+        const auto initResult = reinterpret_cast<void (*)(RED4ext::game::QueryResult*)>(base + 0x8BA038);
+        const auto query = reinterpret_cast<bool (*)(RED4ext::game::HitRepresentationComponent*,
+            const float*, const float*, RED4ext::game::QueryResult*, void*)>(
+                base + 0x8BB428);
+        initResult(&aState->result);
+        aState->initialized = true;
+        aState->status = query(aComponent, &aFrom->X, &aTo->X, &aState->result, nullptr) ? 1 : 2;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        aState->status = -2;
+    }
+}
+
+static void DestroyHitRepQuery(HitRepQueryState* aState) {
+    if (!aState || !aState->initialized) return;
+    __try {
+        const uintptr_t base = reinterpret_cast<uintptr_t>(GetModuleHandleW(L"Cyberpunk2077.exe"));
+        if (!base) return;
+        const auto destroyResult = reinterpret_cast<void (*)(RED4ext::game::QueryResult*)>(base + 0x8B9F40);
+        destroyResult(&aState->result);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+    }
+}
+
+// Return the closest official animated HitRepresentation surface on one candidate NPC. W<=0 is a
+// miss; W=1 is a current-frame hit. Candidate selection remains script-side, while this function
+// only intersects the exact same muzzle ray with the entity's live shapes.
+void QueryVRNpcHitSurface(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame,
+                          RED4ext::Vector4* aOut, int64_t) {
+    RED4ext::Handle<RED4ext::IScriptable> entityHandle;
+    RED4ext::Vector4 from{}, to{};
+    RED4ext::GetParameter(aFrame, &entityHandle);
+    RED4ext::GetParameter(aFrame, &from);
+    RED4ext::GetParameter(aFrame, &to);
+    aFrame->code++;
+    if (!aOut) return;
+    aOut->X = 0.0f;
+    aOut->Y = 0.0f;
+    aOut->Z = 0.0f;
+    aOut->W = 0.0f;
+
+    auto* entity = reinterpret_cast<RED4ext::ent::Entity*>(entityHandle.instance);
+    if (!entity) return;
+
+    float bestDistanceSq = std::numeric_limits<float>::infinity();
+    for (auto& componentHandle : entity->components) {
+        auto* component = componentHandle.instance;
+        if (!component) continue;
+        auto* type = component->GetType();
+        if (!type || type->name != "gameHitRepresentationComponent") continue;
+
+        auto* hitRep = reinterpret_cast<RED4ext::game::HitRepresentationComponent*>(component);
+        HitRepQueryState queryState{};
+        QueryHitRepSurfaceNative(hitRep, &from, &to, &queryState);
+        if (queryState.status == 1) {
+            for (const auto& hit : queryState.result.hitShapes) {
+                const float distanceSq = hit.result.enterDistanceFromOriginSq;
+                const auto& position = hit.result.hitPositionEnter;
+                if (!std::isfinite(distanceSq) || distanceSq < 0.0f ||
+                    !std::isfinite(position.X) || !std::isfinite(position.Y) ||
+                    !std::isfinite(position.Z) || distanceSq >= bestDistanceSq) {
+                    continue;
+                }
+                bestDistanceSq = distanceSq;
+                aOut->X = position.X;
+                aOut->Y = position.Y;
+                aOut->Z = position.Z;
+                aOut->W = 1.0f;
+            }
+        }
+        DestroyHitRepQuery(&queryState);
+    }
+}
+
 // Publish the current ADS/scope zoom factor to shared[28] so the dxgi overlay can scale the
 // barrel laser-dot's screen offset by it (the scope magnifies the image but the bullet still
 // leaves the barrel). CET pushes PlayerStateMachine.ZoomLevel each frame; 1.0 = no zoom.
@@ -894,5 +1035,4 @@ void ResetVRProvCounts(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void
     g_provOverrides = 0;
     for (int i = 0; i < 4; ++i) { g_provLastQ[i]=0; g_provOrigQ[i]=0; g_provCtrlQ[i]=0; g_provHmdQ[i]=0; }
 }
-
 

--- a/src/Natives/Registration.cpp
+++ b/src/Natives/Registration.cpp
@@ -714,6 +714,8 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes() {
     fBarrelRay->AddParam("Float", "y");
     fBarrelRay->AddParam("Float", "z");
     fBarrelRay->AddParam("Int32", "valid");
+    fBarrelRay->AddParam("Int32", "mainVisible");
+    fBarrelRay->AddParam("Int32", "secondVisible");
     rtti->RegisterFunction(fBarrelRay);
     auto fNpcSurface = RED4ext::CGlobalFunction::Create(
         "QueryVRNpcHitSurface", "QueryVRNpcHitSurface", &QueryVRNpcHitSurface);

--- a/src/Natives/Registration.cpp
+++ b/src/Natives/Registration.cpp
@@ -707,6 +707,22 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes() {
     fProvReset->flags = flags; rtti->RegisterFunction(fProvReset);
     auto fProvQM = RED4ext::CGlobalFunction::Create("SetVRProvQuatMode", "SetVRProvQuatMode", &SetVRProvQuatMode);
     fProvQM->flags = flags; fProvQM->AddParam("Int32", "mode"); fProvQM->AddParam("Int32", "axis"); rtti->RegisterFunction(fProvQM);
+    auto fBarrelRay = RED4ext::CGlobalFunction::Create(
+        "SetVRBarrelRayHit", "SetVRBarrelRayHit", &SetVRBarrelRayHit);
+    fBarrelRay->flags = flags;
+    fBarrelRay->AddParam("Float", "x");
+    fBarrelRay->AddParam("Float", "y");
+    fBarrelRay->AddParam("Float", "z");
+    fBarrelRay->AddParam("Int32", "valid");
+    rtti->RegisterFunction(fBarrelRay);
+    auto fNpcSurface = RED4ext::CGlobalFunction::Create(
+        "QueryVRNpcHitSurface", "QueryVRNpcHitSurface", &QueryVRNpcHitSurface);
+    fNpcSurface->flags = flags;
+    fNpcSurface->AddParam("handle:GameObject", "entity");
+    fNpcSurface->AddParam("Vector4", "from");
+    fNpcSurface->AddParam("Vector4", "to");
+    fNpcSurface->SetReturnType("Vector4");
+    rtti->RegisterFunction(fNpcSurface);
     auto fMuzP = RED4ext::CGlobalFunction::Create("SetVRMuzzlePos", "SetVRMuzzlePos", &SetVRMuzzlePos);
     fMuzP->flags = flags;
     fMuzP->AddParam("Float", "x"); fMuzP->AddParam("Float", "y"); fMuzP->AddParam("Float", "z");
@@ -924,4 +940,3 @@ void CyberpunkVR_RegisterHandsNatives() {
     rtti->AddRegisterCallback(RegisterTypes);
     rtti->AddPostRegisterCallback(PostRegisterTypes);
 }
-

--- a/src/Overlay/ImGuiOverlay.cpp
+++ b/src/Overlay/ImGuiOverlay.cpp
@@ -127,6 +127,10 @@ DXGI_FORMAT g_rtvFormat = DXGI_FORMAT_UNKNOWN;
 DXGI_FORMAT g_imguiPsoFormat = DXGI_FORMAT_UNKNOWN;
 // The list the world-projected markers draw into, captured while the frame is still open.
 ImDrawList* g_bgDrawList = nullptr;
+// The counterpart for geometry that has already been projected through the second-eye frustum.
+// It is not part of ImGui's normal draw data; OverlayRecordIntoTarget inserts it only while
+// recording the VRCAM eye, then restores the original draw-data object before returning.
+ImDrawList* g_secondEyeWorldDrawList = nullptr;
 // A small ring of RTVs for targets that are not the swapchain (the second eye). Round-robin
 // rather than one, so a descriptor is never rewritten while a frame that referenced it is still
 // in flight -- the same reason ColorBlit keeps a ring.
@@ -198,6 +202,10 @@ void ReleaseRenderTargets() {
 
 void ShutdownOverlay() {
     ReleaseRenderTargets();
+    if (g_secondEyeWorldDrawList) {
+        IM_DELETE(g_secondEyeWorldDrawList);
+        g_secondEyeWorldDrawList = nullptr;
+    }
     if (g_imguiInitialized) {
         ImGui_ImplDX12_Shutdown();
         ImGui_ImplWin32_Shutdown();
@@ -579,6 +587,15 @@ void OverlayRender(IDXGISwapChain* swapChain) {
 
     ImGui::NewFrame();
 
+    if (!g_secondEyeWorldDrawList) {
+        g_secondEyeWorldDrawList = IM_NEW(ImDrawList)(ImGui::GetDrawListSharedData());
+        g_secondEyeWorldDrawList->_OwnerName = "##SecondEyeWorld";
+    }
+    g_secondEyeWorldDrawList->_ResetForNewFrame();
+    g_secondEyeWorldDrawList->PushTextureID(ImGui::GetIO().Fonts->TexID);
+    g_secondEyeWorldDrawList->PushClipRect(
+        ImVec2(0.0f, 0.0f), ImGui::GetIO().DisplaySize, false);
+
     DrawHandLocatorOverlay();
     DrawBarrelCrosshair();
     DrawCompactAdsCameraTelemetry();
@@ -701,13 +718,13 @@ bool OverlayIsVisible() {
 //      RENDER_TARGET, which is where the caller records this -- so it needs no barrier of its own,
 //      and asserts nothing about a resource it does not own.
 //
-// What is NOT recorded is the background draw list: the hand locator, the aim ray and the barrel
+// What is NOT replayed is the MAIN background draw list: the hand locator, the aim ray and the barrel
 // cross are projected with one frustum, so their pixels are only true for the eye they were
 // projected for. Reusing them here would put a second, flat copy at optical infinity beside the
-// correct one -- and the barrel dot already has its own properly projected second-eye draw
-// (ColorBlit::RecordDot with CyberpunkVR_BarrelDotNdcX2). The foreground list is kept, because after
-// that move it holds exactly what IS screen-space: ImGui's software mouse cursor, which has to be in
-// both eyes to be usable.
+// correct one. World markers that do have a second-eye projection belong in the dedicated
+// g_secondEyeWorldDrawList, which is inserted only for this pass. The foreground list is kept,
+// because after that move it holds exactly what IS screen-space: ImGui's software mouse cursor,
+// which has to be in both eyes to be usable.
 // ================================================================================================
 
 extern "C" __declspec(dllexport) int      CyberpunkVR_OverlaySecondEye = 1;
@@ -750,7 +767,11 @@ bool OverlayRecordIntoTarget(ID3D12GraphicsCommandList* cmdList, ID3D12Resource*
     if (g_imguiPsoFormat == DXGI_FORMAT_UNKNOWN) return false;
 
     ImDrawData* drawData = ImGui::GetDrawData();
-    if (!drawData || !drawData->Valid || drawData->CmdListsCount <= 0) return false;
+    if (!drawData || !drawData->Valid) return false;
+    const bool haveSecondEyeWorld = g_secondEyeWorldDrawList &&
+                                    g_secondEyeWorldDrawList->VtxBuffer.Size > 0 &&
+                                    g_secondEyeWorldDrawList->IdxBuffer.Size > 0;
+    if (drawData->CmdListsCount <= 0 && !haveSecondEyeWorld) return false;
 
     const D3D12_RESOURCE_DESC desc = target->GetDesc();
     const uint32_t wantW = static_cast<uint32_t>(drawData->DisplaySize.x);
@@ -793,7 +814,7 @@ bool OverlayRecordIntoTarget(ID3D12GraphicsCommandList* cmdList, ID3D12Resource*
     rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
     g_device->CreateRenderTargetView(target, &rtvDesc, rtv);
 
-    // THE TWO EDITS TO THE DRAW DATA, both undone before returning: the draw data is the context's,
+    // THE TEMPORARY EDITS TO THE DRAW DATA, all undone before returning: the draw data is the context's,
     // and eye 0 has already consumed it this frame, but anything left changed here would be read by
     // the NEXT frame's overlay before NewFrame resets it.
     //
@@ -802,6 +823,8 @@ bool OverlayRecordIntoTarget(ID3D12GraphicsCommandList* cmdList, ID3D12Resource*
     // whole overlay LEFT -- which is where a panel nearer than infinity sits in the right eye. Clip
     // rectangles are taken relative to DisplayPos by the backend, so they follow it exactly.
     const ImVec2 savedPos = drawData->DisplayPos;
+    const int savedTotalIdxCount = drawData->TotalIdxCount;
+    const int savedTotalVtxCount = drawData->TotalVtxCount;
     drawData->DisplayPos.x += shiftPx;
 
     // And the background list is dropped for this pass. Erasing from the vector keeps its capacity,
@@ -814,7 +837,25 @@ bool OverlayRecordIntoTarget(ID3D12GraphicsCommandList* cmdList, ID3D12Resource*
         }
     }
     if (bgIndex >= 0) {
+        drawData->TotalIdxCount -= g_bgDrawList->IdxBuffer.Size;
+        drawData->TotalVtxCount -= g_bgDrawList->VtxBuffer.Size;
         drawData->CmdLists.erase(drawData->CmdLists.Data + bgIndex);
+        drawData->CmdListsCount = drawData->CmdLists.Size;
+    }
+
+    // Unlike MAIN's background list, this list was built with the second eye's own projected
+    // coordinates. Insert it below windows/cursor so the F10 menu still covers the world marker.
+    if (haveSecondEyeWorld) {
+        // DisplayPos shifts the flat menu to its configured depth. The world-projected dot already
+        // has its own stereo position, so offset its vertices by the same amount to cancel that
+        // global transform for this list only.
+        if (shiftPx != 0.0f) {
+            for (ImDrawVert& vertex : g_secondEyeWorldDrawList->VtxBuffer)
+                vertex.pos.x += shiftPx;
+        }
+        drawData->CmdLists.insert(drawData->CmdLists.Data, g_secondEyeWorldDrawList);
+        drawData->TotalIdxCount += g_secondEyeWorldDrawList->IdxBuffer.Size;
+        drawData->TotalVtxCount += g_secondEyeWorldDrawList->VtxBuffer.Size;
         drawData->CmdListsCount = drawData->CmdLists.Size;
     }
 
@@ -826,10 +867,20 @@ bool OverlayRecordIntoTarget(ID3D12GraphicsCommandList* cmdList, ID3D12Resource*
         ImGui_ImplDX12_RenderDrawData(drawData, cmdList);
     }
 
+    if (haveSecondEyeWorld) {
+        drawData->CmdLists.erase(drawData->CmdLists.Data);
+        if (shiftPx != 0.0f) {
+            for (ImDrawVert& vertex : g_secondEyeWorldDrawList->VtxBuffer)
+                vertex.pos.x -= shiftPx;
+        }
+    }
+
     if (bgIndex >= 0) {
         drawData->CmdLists.insert(drawData->CmdLists.Data + bgIndex, g_bgDrawList);
-        drawData->CmdListsCount = drawData->CmdLists.Size;
     }
+    drawData->CmdListsCount = drawData->CmdLists.Size;
+    drawData->TotalIdxCount = savedTotalIdxCount;
+    drawData->TotalVtxCount = savedTotalVtxCount;
     drawData->DisplayPos = savedPos;
 
     if (anything) ++CyberpunkVR_DebugOverlaySecondEyeDraws;

--- a/src/Overlay/OverlayDebugDraw.cpp
+++ b/src/Overlay/OverlayDebugDraw.cpp
@@ -279,10 +279,10 @@ void DrawHandLocatorOverlay() {
     }
 }
 
-// The barrel dot, in NDC, for the eye the overlay cannot reach. Written by DrawBarrelCrosshair
-// below; read by the VRCAM eye composite (openxr_capture.cpp) and by the desktop mirror
-// (sync_stereo.cpp). The tick is what makes a stale value harmless: the consumers ignore it once
-// it stops being refreshed, so holstering the weapon removes the dot instead of freezing it.
+// The finalized barrel-dot NDC values written by DrawBarrelCrosshair below. The second-eye value
+// feeds the dedicated HMD world list, while the shared values are also consumed by the desktop
+// mirror (sync_stereo.cpp). The tick is what makes a stale value harmless: consumers ignore it
+// once it stops being refreshed, so holstering the weapon removes the dot instead of freezing it.
 extern "C" __declspec(dllexport) float    CyberpunkVR_BarrelDotNdcX = 0.0f;
 // The SECOND eye needs its own value. The dot marks where the bullet goes, and the bullet
 // line passes through the FIRST eye (the game aligns the weapon to its camera, which is
@@ -373,6 +373,73 @@ void DrawCompactAdsCameraTelemetry() {
     ImGui::End();
 }
 
+void DrawRadialLaserSpot(ImDrawList* drawList, const ImVec2& center, float coreRadiusPx) {
+    if (!drawList || !(coreRadiusPx > 0.0f)) return;
+
+    constexpr float kOuterCoreRatio = 2.5f;
+    constexpr float kLn2 = 0.69314718f;
+    constexpr float kRingCoreDistances[] = {
+        0.25f, 0.50f, 0.75f, 1.00f, 1.30f, 1.65f, 2.00f, 2.25f, 2.50f
+    };
+    constexpr int kRingCount = static_cast<int>(IM_ARRAYSIZE(kRingCoreDistances));
+    const float outerRadiusPx = coreRadiusPx * kOuterCoreRatio;
+    const float segmentEstimate = 3.1415926535f /
+        acosf(std::clamp(1.0f - 0.30f / std::max(outerRadiusPx, 0.31f), -1.0f, 1.0f));
+    const int segments = std::clamp(static_cast<int>(ceilf(segmentEstimate)), 12, 128);
+    const int vertexCount = 1 + kRingCount * segments;
+    const int indexCount = segments * 3 + (kRingCount - 1) * segments * 6;
+    const ImVec2 uv = ImGui::GetFontTexUvWhitePixel();
+
+    auto colorAt = [&](float coreDistance) -> ImU32 {
+        const float intensity = expf(-kLn2 * coreDistance * coreDistance);
+        const float fadeT = std::clamp((coreDistance - 2.25f) / 0.25f, 0.0f, 1.0f);
+        const float smoothFade = fadeT * fadeT * (3.0f - 2.0f * fadeT);
+        const float alpha = intensity * (1.0f - smoothFade);
+        const float hotCore = expf(-4.0f * coreDistance * coreDistance);
+        const float green = 0.045f + (0.82f - 0.045f) * hotCore;
+        const float blue = 0.045f + (0.68f - 0.045f) * hotCore;
+        return ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, green, blue, alpha));
+    };
+
+    drawList->PrimReserve(indexCount, vertexCount);
+    const ImDrawIdx base = static_cast<ImDrawIdx>(drawList->_VtxCurrentIdx);
+    drawList->PrimWriteVtx(center, uv, colorAt(0.0f));
+    for (int ring = 0; ring < kRingCount; ++ring) {
+        const float coreDistance = kRingCoreDistances[ring];
+        const float ringRadiusPx = coreRadiusPx * coreDistance;
+        const ImU32 color = colorAt(coreDistance);
+        for (int segment = 0; segment < segments; ++segment) {
+            const float angle = (2.0f * 3.1415926535f * static_cast<float>(segment)) /
+                                static_cast<float>(segments);
+            drawList->PrimWriteVtx(
+                ImVec2(center.x + cosf(angle) * ringRadiusPx,
+                       center.y + sinf(angle) * ringRadiusPx),
+                uv, color);
+        }
+    }
+
+    const ImDrawIdx firstRing = static_cast<ImDrawIdx>(base + 1);
+    for (int segment = 0; segment < segments; ++segment) {
+        const ImDrawIdx next = static_cast<ImDrawIdx>((segment + 1) % segments);
+        drawList->PrimWriteIdx(base);
+        drawList->PrimWriteIdx(static_cast<ImDrawIdx>(firstRing + segment));
+        drawList->PrimWriteIdx(static_cast<ImDrawIdx>(firstRing + next));
+    }
+    for (int ring = 1; ring < kRingCount; ++ring) {
+        const ImDrawIdx inner = static_cast<ImDrawIdx>(base + 1 + (ring - 1) * segments);
+        const ImDrawIdx outer = static_cast<ImDrawIdx>(base + 1 + ring * segments);
+        for (int segment = 0; segment < segments; ++segment) {
+            const ImDrawIdx next = static_cast<ImDrawIdx>((segment + 1) % segments);
+            drawList->PrimWriteIdx(static_cast<ImDrawIdx>(inner + segment));
+            drawList->PrimWriteIdx(static_cast<ImDrawIdx>(outer + segment));
+            drawList->PrimWriteIdx(static_cast<ImDrawIdx>(outer + next));
+            drawList->PrimWriteIdx(static_cast<ImDrawIdx>(inner + segment));
+            drawList->PrimWriteIdx(static_cast<ImDrawIdx>(outer + next));
+            drawList->PrimWriteIdx(static_cast<ImDrawIdx>(inner + next));
+        }
+    }
+}
+
 void DrawBarrelCrosshair() {
     int laserDotMode = g_liveControls.xrLaserDotMode;
     if (laserDotMode < 0 || laserDotMode > 2) laserDotMode = 1;
@@ -388,9 +455,8 @@ void DrawBarrelCrosshair() {
     float rad = 3.0f;
     
     if (!g_drawBarrelCross || enableLaser < 0.9f){
-        // The second eye is stamped by the capture path rather than ImGui. Clear its publication
-        // immediately when the common UI/weapon gate closes instead of waiting for the 250 ms
-        // consumer safety timeout.
+        // Clear the legacy mirror publication immediately when the common UI/weapon gate closes;
+        // the HMD's dedicated second-eye ImGui list is reset independently every frame.
         CyberpunkVR_BarrelDotTick = 0;
         CyberpunkVR_BarrelDotSecondVisible = 0;
         /*rad = 0.0f;
@@ -493,6 +559,50 @@ void DrawBarrelCrosshair() {
 
     const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
     if (displaySize.x <= 1.0f || displaySize.y <= 1.0f) return;
+
+    // Convert the user-facing beam radius to pixels through the same live projection that places
+    // the dot. Modes 0/1 use a stable 2 m reference depth. In mode 2 the physical spot widens with
+    // beam travel, while perspective still makes its apparent size decrease toward the beam's
+    // angular divergence. The far-size floor is therefore angular rather than a fixed pixel count.
+    // The very large angular ceiling is only a numerical safety guard for near-zero view depth.
+    constexpr float kLaserDotReferenceDepthM = 2.0f;
+    constexpr float kLaserDotHalfDivergenceRad = 0.00075f;
+    constexpr float kLaserDotMissAngularRadiusRad = 0.0005f;
+    constexpr float kLaserDotSafetyMaxAngularRadius = 1.0f;
+    const float radiusMm = std::clamp(static_cast<float>(g_liveControls.xrLaserDotRadiusMm), 1.0f, 50.0f);
+    const float baseRadiusM = radiusMm * 0.001f;
+    const bool scaleWithDistance = surfaceMode && g_liveControls.xrLaserDotScaleWithDistance != 0;
+    float angularRadius = baseRadiusM / kLaserDotReferenceDepthM;
+    if (scaleWithDistance) {
+        if (!haveRayHit) {
+            // A miss is only an optical-infinity direction cue, not a physical beam footprint.
+            // Keep it visibly smaller than the asymptotic surface spot.
+            angularRadius = tanf(kLaserDotMissAngularRadiusRad);
+        } else {
+            float lx = 0.0f, ly = 0.0f, lz = 0.0f;
+            RotateVectorByQuaternion(hitx - hcx, hity - hcy, hitz - hcz,
+                                     -cqx, -cqy, -cqz, cqw, &lx, &ly, &lz);
+            if (ly > 0.01f) {
+                float beamTravelM = ly;
+                if (haveWorld) {
+                    const float bdx = hitx - mpx;
+                    const float bdy = hity - mpy;
+                    const float bdz = hitz - mpz;
+                    beamTravelM = sqrtf(bdx * bdx + bdy * bdy + bdz * bdz);
+                }
+                const float beamSpreadM = beamTravelM * tanf(kLaserDotHalfDivergenceRad);
+                const float surfaceRadiusM = sqrtf(baseRadiusM * baseRadiusM + beamSpreadM * beamSpreadM);
+                angularRadius = surfaceRadiusM / ly;
+            } else {
+                angularRadius = kLaserDotSafetyMaxAngularRadius;
+            }
+        }
+    }
+    float tanHalfX = 0.0f, tanHalfY = 0.0f;
+    if (GetOverlayProjTans(displaySize, &tanHalfX, &tanHalfY) && tanHalfX > 0.0001f) {
+        angularRadius = std::clamp(angularRadius, 0.0f, kLaserDotSafetyMaxAngularRadius);
+        rad = angularRadius * (displaySize.x * 0.5f) / tanHalfX;
+    }
 
     // The camera's right axis, from the same quaternion the view is built with. Column 0 of the
     // rotation -- the engine's camera frame is X right, Y forward, Z up (verified live by
@@ -641,7 +751,16 @@ void DrawBarrelCrosshair() {
                 : (CyberpunkVR_BarrelDotNdcX + (surfaceMode ? 0.0f : dx)))
                 + CyberpunkVR_BarrelDotOffX2;
         }
-        CyberpunkVR_BarrelDotRadiusPx = rad;
+        // The published second-eye NDC is the authoritative finalized result for every mode:
+        // mode 0's steady direction plus constant parallax, mode 1's world point, or mode 2's
+        // per-eye surface projection. Convert it back to ImGui pixels for the dedicated HMD list
+        // so this mesh cannot bypass the mode-specific result or the second-eye tuning offset.
+        const ImVec2 secondEyeSc{
+            (CyberpunkVR_BarrelDotNdcX2 + 1.0f) * displaySize.x * 0.5f,
+            (1.0f - CyberpunkVR_BarrelDotNdcY) * displaySize.y * 0.5f};
+        // `rad` is the user-facing half-intensity core. The legacy desktop-mirror RecordDot path
+        // receives the full halo extent; both ImGui eye paths draw directly from the core radius.
+        CyberpunkVR_BarrelDotRadiusPx = rad * 2.5f;
         CyberpunkVR_BarrelDotTick = GetTickCount64();
         const bool mainDotVisible = !surfaceMode || !rayFresh || mainVisible > 0.5f;
         CyberpunkVR_BarrelDotSecondVisible =
@@ -650,8 +769,12 @@ void DrawBarrelCrosshair() {
         // Background list: world-projected, see DrawHandLocatorOverlay.
         ImDrawList* dl = ImGui::GetBackgroundDrawList();
         if (dl && mainDotVisible) {
-            dl->AddCircleFilled(sc, rad, IM_COL32(255, 60, 60, 255));
+            DrawRadialLaserSpot(dl, sc, rad);
             //dl->AddCircle(sc, 11.0f, IM_COL32(255, 255, 255, 235), 0, 2.0f);
+        }
+        if (g_secondEyeWorldDrawList && CyberpunkVR_BarrelDotSecondEye &&
+            CyberpunkVR_BarrelDotSecondVisible) {
+            DrawRadialLaserSpot(g_secondEyeWorldDrawList, secondEyeSc, rad);
         }
     }
 }

--- a/src/Overlay/OverlayDebugDraw.cpp
+++ b/src/Overlay/OverlayDebugDraw.cpp
@@ -315,6 +315,7 @@ extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 2;
 extern "C" int CyberpunkVR_MainIsRightEye;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_BarrelDotTick = 0;
 extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondEye = 1;
+extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondVisible = 1;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_DebugBarrelDotDraws = 0;
 
 // EXACT barrel crosshair. The plugin publishes the weapon muzzle WORLD forward (shared[24..26]); we
@@ -374,10 +375,20 @@ void DrawCompactAdsCameraTelemetry() {
 void DrawBarrelCrosshair() {
     
     const float enableLaser = OpenXRManager::Get().GetSharedSlot(144);   // weapon flag (was [126]: HMD-Z collision)
+    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
+    const bool raycastActive = g_drawBarrelCross && surfaceMode && enableLaser >= 0.9f;
+    // CET owns every physics query. Publish the UI/mode gate before returning so disabling a dot
+    // stops muzzle and visibility work rather than merely stopping the final draw.
+    OpenXRManager::Get().SetSharedSlot(vrshared::kBarrelRayActive, raycastActive ? 1.0f : 0.0f);
     
     float rad = 3.0f;
     
     if (!g_drawBarrelCross || enableLaser < 0.9f){
+        // The second eye is stamped by the capture path rather than ImGui. Clear its publication
+        // immediately when the common UI/weapon gate closes instead of waiting for the 250 ms
+        // consumer safety timeout.
+        CyberpunkVR_BarrelDotTick = 0;
+        CyberpunkVR_BarrelDotSecondVisible = 0;
         /*rad = 0.0f;
         // Background list: world-projected, see DrawHandLocatorOverlay.
         ImDrawList* dl = ImGui::GetBackgroundDrawList();
@@ -438,12 +449,12 @@ void DrawBarrelCrosshair() {
     const bool haveWorld = (mpx * mpx + mpy * mpy + mpz * mpz) > 1.0f &&
                            (hcx * hcx + hcy * hcy + hcz * hcz) > 1.0f;
 
-    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
     // CET owns the physics query and publishes one world-space hit packet. A sequence that stops
     // changing means the publisher was interrupted; never leave the last dot glued to a wall.
     static uint32_t s_lastRaySeq = 0;
     static uint64_t s_lastRayTick = 0;
     float hitx = 0.0f, hity = 0.0f, hitz = 0.0f, hitValid = 0.0f;
+    float mainVisible = 1.0f, secondVisible = 1.0f;
     uint32_t raySeq = 0;
     bool rayPacket = false;
     for (int attempt = 0; surfaceMode && attempt < 3 && !rayPacket; ++attempt) {
@@ -455,11 +466,15 @@ void DrawBarrelCrosshair() {
         const float y = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 1);
         const float z = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 2);
         const float v = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitValid);
+        const float vm = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelMainVisible);
+        const float vs = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelSecondVisible);
         std::atomic_thread_fence(std::memory_order_acquire);
         const uint32_t s1 = static_cast<uint32_t>(
             OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRaySeq));
         if (s0 == s1 && !(s1 & 1u)) {
-            hitx = x; hity = y; hitz = z; hitValid = v; raySeq = s1; rayPacket = true;
+            hitx = x; hity = y; hitz = z; hitValid = v;
+            mainVisible = vm; secondVisible = vs;
+            raySeq = s1; rayPacket = true;
         }
     }
     if (rayPacket && raySeq != s_lastRaySeq) {
@@ -486,6 +501,36 @@ void DrawBarrelCrosshair() {
     float halfIpd = CyberpunkVRPort_HalfIpd();
     if (!(halfIpd > 0.0001f)) halfIpd = OpenXRManager::Get().GetSharedSlot(95);
     if (!(halfIpd > 0.0001f)) halfIpd = 0.0325f;
+
+    // Publish exactly the two synthetic eye origins used by the dot projection. Naming these
+    // MAIN/second avoids assuming which physical eye MAIN owns when the live eye sign is flipped.
+    // CET reads the pair through this seqlock before issuing its game-thread visibility rays.
+    const float sMain = (CyberpunkVR_BarrelDotEyeSign >= 0) ? +1.0f : -1.0f;
+    const float mainEye[3] = {
+        hcx + rgt[0] * halfIpd * sMain,
+        hcy + rgt[1] * halfIpd * sMain,
+        hcz + rgt[2] * halfIpd * sMain
+    };
+    const float secondEye[3] = {
+        hcx - rgt[0] * halfIpd * sMain,
+        hcy - rgt[1] * halfIpd * sMain,
+        hcz - rgt[2] * halfIpd * sMain
+    };
+    {
+        static uint32_t s_eyeSeq = 0;
+        uint32_t nextEven = s_eyeSeq + 2u;
+        if (nextEven >= 1000000u) nextEven = 2u;
+        auto& xr = OpenXRManager::Get();
+        xr.SetSharedSlot(vrshared::kBarrelEyeSeq, static_cast<float>(nextEven - 1u));
+        std::atomic_thread_fence(std::memory_order_release);
+        for (int i = 0; i < 3; ++i) {
+            xr.SetSharedSlot(vrshared::kBarrelMainEyeX + i, mainEye[i]);
+            xr.SetSharedSlot(vrshared::kBarrelSecondEyeX + i, secondEye[i]);
+        }
+        std::atomic_thread_fence(std::memory_order_release);
+        xr.SetSharedSlot(vrshared::kBarrelEyeSeq, static_cast<float>(nextEven));
+        s_eyeSeq = nextEven;
+    }
 
     // Screen position of the impact point as seen from one eye. sign: -1 = MAIN/left, +1 = VRCAM.
     static float s_dbgLy[2] = {0.0f, 0.0f};
@@ -529,7 +574,6 @@ void DrawBarrelCrosshair() {
     // Sign fixed by observation: a fixed world point must slide LEFT on screen when the eye
     // moves RIGHT, and it was doing the opposite -- the second eye sat right of the first. So
     // MAIN is the +right eye here, not the -right one. Live switch rather than a silent constant.
-    const float sMain = (CyberpunkVR_BarrelDotEyeSign >= 0) ? +1.0f : -1.0f;
     // Do NOT require both, and do NOT fall back. Requiring both meant one failed projection
     // dropped the pair onto the direction path, which is wrong for the second eye BY
     // CONSTRUCTION -- a mark at infinity cannot show a finite impact from an eye off the line.
@@ -595,10 +639,13 @@ void DrawBarrelCrosshair() {
         }
         CyberpunkVR_BarrelDotRadiusPx = rad;
         CyberpunkVR_BarrelDotTick = GetTickCount64();
+        const bool mainDotVisible = !surfaceMode || !rayFresh || mainVisible > 0.5f;
+        CyberpunkVR_BarrelDotSecondVisible =
+            (!surfaceMode || !rayFresh || secondVisible > 0.5f) ? 1 : 0;
 
         // Background list: world-projected, see DrawHandLocatorOverlay.
         ImDrawList* dl = ImGui::GetBackgroundDrawList();
-        if (dl) {
+        if (dl && mainDotVisible) {
             dl->AddCircleFilled(sc, rad, IM_COL32(255, 60, 60, 255));
             //dl->AddCircle(sc, 11.0f, IM_COL32(255, 255, 255, 235), 0, 2.0f);
         }

--- a/src/Overlay/OverlayDebugDraw.cpp
+++ b/src/Overlay/OverlayDebugDraw.cpp
@@ -10,6 +10,7 @@
 
 #include "Overlay/ImGuiOverlay.hpp"
 #include "Overlay/LiveControlsUi.hpp"
+#include "Core/LiveControls.hpp"
 #include "Runtimes/OpenXRManager.hpp"
 #include <algorithm>
 #include <atomic>
@@ -311,7 +312,7 @@ extern "C" __declspec(dllexport) float    CyberpunkVR_BarrelDotOffX2 = 0.0f;
 // 0 = one projection for both eyes plus a constant parallax on the second (simple, steady).
 // 1 = a real world point projected per eye (exact, but only as steady as the muzzle transform).
 // 2 = the closest raycast surface projected per eye; a miss uses mode 0.
-extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 2;
+extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 1;
 extern "C" int CyberpunkVR_MainIsRightEye;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_BarrelDotTick = 0;
 extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondEye = 1;
@@ -373,9 +374,12 @@ void DrawCompactAdsCameraTelemetry() {
 }
 
 void DrawBarrelCrosshair() {
-    
+    int laserDotMode = g_liveControls.xrLaserDotMode;
+    if (laserDotMode < 0 || laserDotMode > 2) laserDotMode = 1;
+    CyberpunkVR_BarrelDotWorld = laserDotMode;
+
     const float enableLaser = OpenXRManager::Get().GetSharedSlot(144);   // weapon flag (was [126]: HMD-Z collision)
-    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
+    const bool surfaceMode = laserDotMode == 2;
     const bool raycastActive = g_drawBarrelCross && surfaceMode && enableLaser >= 0.9f;
     // CET owns every physics query. Publish the UI/mode gate before returning so disabling a dot
     // stops muzzle and visibility work rather than merely stopping the final draw.

--- a/src/Overlay/OverlayDebugDraw.cpp
+++ b/src/Overlay/OverlayDebugDraw.cpp
@@ -12,6 +12,7 @@
 #include "Overlay/LiveControlsUi.hpp"
 #include "Runtimes/OpenXRManager.hpp"
 #include <algorithm>
+#include <atomic>
 #include <cfloat>
 #include <cmath>
 #include <cstdio>
@@ -22,6 +23,7 @@
 #include <imgui_impl_win32.h>
 #include "im3d.h"
 #include "Camera/CameraLink.hpp"   // cvr::camera::BarrelFrameRead
+#include "Utils/SharedSlots.hpp"
 #include "Overlay/OverlayInternal.hpp"
 
 extern volatile int g_verboseLog; // per-frame log spam toggle (default off)
@@ -308,7 +310,8 @@ extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotEyeSign = 1;
 extern "C" __declspec(dllexport) float    CyberpunkVR_BarrelDotOffX2 = 0.0f;
 // 0 = one projection for both eyes plus a constant parallax on the second (simple, steady).
 // 1 = a real world point projected per eye (exact, but only as steady as the muzzle transform).
-extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 1;
+// 2 = the closest raycast surface projected per eye; a miss uses mode 0.
+extern "C" __declspec(dllexport) int      CyberpunkVR_BarrelDotWorld = 2;
 extern "C" int CyberpunkVR_MainIsRightEye;
 extern "C" __declspec(dllexport) uint64_t CyberpunkVR_BarrelDotTick = 0;
 extern "C" __declspec(dllexport) int32_t  CyberpunkVR_BarrelDotSecondEye = 1;
@@ -435,6 +438,40 @@ void DrawBarrelCrosshair() {
     const bool haveWorld = (mpx * mpx + mpy * mpy + mpz * mpz) > 1.0f &&
                            (hcx * hcx + hcy * hcy + hcz * hcz) > 1.0f;
 
+    const bool surfaceMode = CyberpunkVR_BarrelDotWorld == 2;
+    // CET owns the physics query and publishes one world-space hit packet. A sequence that stops
+    // changing means the publisher was interrupted; never leave the last dot glued to a wall.
+    static uint32_t s_lastRaySeq = 0;
+    static uint64_t s_lastRayTick = 0;
+    float hitx = 0.0f, hity = 0.0f, hitz = 0.0f, hitValid = 0.0f;
+    uint32_t raySeq = 0;
+    bool rayPacket = false;
+    for (int attempt = 0; surfaceMode && attempt < 3 && !rayPacket; ++attempt) {
+        const uint32_t s0 = static_cast<uint32_t>(
+            OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRaySeq));
+        if (s0 == 0u || (s0 & 1u)) continue;
+        std::atomic_thread_fence(std::memory_order_acquire);
+        const float x = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 0);
+        const float y = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 1);
+        const float z = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitX + 2);
+        const float v = OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRayHitValid);
+        std::atomic_thread_fence(std::memory_order_acquire);
+        const uint32_t s1 = static_cast<uint32_t>(
+            OpenXRManager::Get().GetSharedSlot(vrshared::kBarrelRaySeq));
+        if (s0 == s1 && !(s1 & 1u)) {
+            hitx = x; hity = y; hitz = z; hitValid = v; raySeq = s1; rayPacket = true;
+        }
+    }
+    if (rayPacket && raySeq != s_lastRaySeq) {
+        s_lastRaySeq = raySeq;
+        s_lastRayTick = GetTickCount64();
+    }
+    const uint64_t nowTick = GetTickCount64();
+    const bool rayFresh = rayPacket && s_lastRayTick != 0 && (nowTick - s_lastRayTick) <= 20u;
+    const bool haveRayHit = surfaceMode && rayFresh && hitValid > 0.5f &&
+                            (hcx * hcx + hcy * hcy + hcz * hcz) > 1.0f &&
+                            (hitx * hitx + hity * hity + hitz * hitz) > 1.0f;
+
     const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
     if (displaySize.x <= 1.0f || displaySize.y <= 1.0f) return;
 
@@ -471,6 +508,16 @@ void DrawBarrelCrosshair() {
         if (!okp) s_dbgWhy = 3.0f;
         return okp;
     };
+    auto surfaceDotForEye = [&](float sign, ImVec2* out) -> bool {
+        if (!haveRayHit) return false;
+        const float ex = hcx + rgt[0] * halfIpd * sign;
+        const float ey = hcy + rgt[1] * halfIpd * sign;
+        const float ez = hcz + rgt[2] * halfIpd * sign;
+        float lx = 0.0f, ly = 0.0f, lz = 0.0f;
+        RotateVectorByQuaternion(hitx - ex, hity - ey, hitz - ez,
+                                 -cqx, -cqy, -cqz, cqw, &lx, &ly, &lz);
+        return ProjectHeadSpacePointToScreen(lx, lz, -ly, displaySize, out);
+    };
 
     ImVec2 sc{};
     // game-cam-local (Yfwd/Xright/Zup) -> OpenXR view convention (forward -Z, right +X, up +Y): (x, z, -y)
@@ -487,13 +534,13 @@ void DrawBarrelCrosshair() {
     // dropped the pair onto the direction path, which is wrong for the second eye BY
     // CONSTRUCTION -- a mark at infinity cannot show a finite impact from an eye off the line.
     // That is what made the right eye's dot sit right of the shot on half the frames.
-    const bool mainOk = dotForEye(sMain, &sc);
-    if (!dotForEye(-sMain, &scRight)) scRight = sc;
+    const bool mainOk = surfaceMode ? surfaceDotForEye(sMain, &sc) : dotForEye(sMain, &sc);
+    if (!(surfaceMode ? surfaceDotForEye(-sMain, &scRight) : dotForEye(-sMain, &scRight))) scRight = sc;
     // OFF by default. The world point is the exact answer, but it depends on a muzzle transform
     // that goes to identity between frames (fists, and recoil right after a shot) -- latched, it
     // then lags and the two dots visibly part company. The simple form below has none of that:
     // one projection, plus a constant parallax for the second eye.
-    const bool worldOk = mainOk && (CyberpunkVR_BarrelDotWorld != 0);
+    const bool worldOk = mainOk && (surfaceMode ? haveRayHit : CyberpunkVR_BarrelDotWorld != 0);
     {
         static int s_said = -1;
         const int now = worldOk ? 1 : 0;
@@ -508,7 +555,7 @@ void DrawBarrelCrosshair() {
         }
     }
     // With world data present the direction path is not a fallback, it is a wrong answer.
-    if (CyberpunkVR_BarrelDotWorld && haveWorld && !worldOk) return;
+    if (CyberpunkVR_BarrelDotWorld == 1 && haveWorld && !worldOk) return;
     if (worldOk || ProjectHeadSpacePointToScreen(vx, vz, -vy, displaySize, &sc)) {
         // NO ZOOM COMPENSATION HERE ANY MORE (dabinn, TofuExpress 2cb7b031). ADS magnification is
         // already in the projection this point was built with -- GetOverlayProjTans divides the
@@ -543,7 +590,7 @@ void DrawBarrelCrosshair() {
             }
             CyberpunkVR_BarrelDotNdcX2 = (worldOk
                 ? ((scRight.x / displaySize.x) * 2.0f - 1.0f)   // its own eye, its own ray
-                : (CyberpunkVR_BarrelDotNdcX + dx))
+                : (CyberpunkVR_BarrelDotNdcX + (surfaceMode ? 0.0f : dx)))
                 + CyberpunkVR_BarrelDotOffX2;
         }
         CyberpunkVR_BarrelDotRadiusPx = rad;

--- a/src/Overlay/OverlayPanels.cpp
+++ b/src/Overlay/OverlayPanels.cpp
@@ -695,10 +695,33 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                                       "the weapon arm. Either way the shot leaves the real muzzle, for guns and\n"
                                       "projectiles alike, and free-look while aiming is preserved.");
                 }
-                ImGui::Checkbox("Weapon Aim laser dot (where the bullet hits)", &g_drawBarrelCross);
+                ImGui::Checkbox("Laser dot", &g_drawBarrelCross);
                 if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip("Red dot projected from the actual weapon muzzle direction through the\n"
-                                      "game camera -- marks exactly where the bullet will fly.");
+                    ImGui::SetTooltip("Show a red aiming dot projected from the weapon muzzle.\n"
+                                      "Select how its depth is determined with the mode selector.");
+                }
+                ImGui::SameLine();
+                ImGui::SetNextItemWidth(190.0f);
+                static const char* kLaserDotModes[] = {
+                    "Steady projection",
+                    "Real world point",
+                    "Surface raycast"
+                };
+                int laserDotMode = state.xrLaserDotMode;
+                if (laserDotMode < 0 || laserDotMode > 2) laserDotMode = 1;
+                if (ImGui::Combo("##laserDotMode", &laserDotMode, kLaserDotModes,
+                                 IM_ARRAYSIZE(kLaserDotModes))) {
+                    state.xrLaserDotMode = laserDotMode;
+                    changed = true;
+                }
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip(
+                        "Steady projection\n"
+                        "Simple and steady stereo projection.\n\n"
+                        "Real world point\n"
+                        "Places the dot at a real point in 3D space ahead of the weapon.\n\n"
+                        "Surface raycast\n"
+                        "Places the dot on the surface hit by the weapon's pointing ray.");
                 }
             }
             ImGui::Separator();

--- a/src/Overlay/OverlayPanels.cpp
+++ b/src/Overlay/OverlayPanels.cpp
@@ -723,6 +723,29 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                         "Surface raycast\n"
                         "Places the dot on the surface hit by the weapon's pointing ray.");
                 }
+                ImGui::SetNextItemWidth(220.0f);
+                int laserDotRadiusMm = static_cast<int>(std::lround(state.xrLaserDotRadiusMm));
+                if (ImGui::SliderInt("Spot radius", &laserDotRadiusMm, 1, 50, "%d mm")) {
+                    state.xrLaserDotRadiusMm = static_cast<float>(laserDotRadiusMm);
+                    changed = true;
+                }
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Set the laser dot radius in world-space millimetres.\n"
+                                      "The final pixel size adapts to the current resolution and view.");
+                }
+                ImGui::SameLine();
+                const bool distanceScaleAvailable = laserDotMode == 2;
+                if (!distanceScaleAvailable) ImGui::BeginDisabled();
+                bool scaleWithDistance = state.xrLaserDotScaleWithDistance != 0;
+                if (ImGui::Checkbox("Scale with distance", &scaleWithDistance)) {
+                    state.xrLaserDotScaleWithDistance = scaleWithDistance ? 1 : 0;
+                    changed = true;
+                }
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                    ImGui::SetTooltip("Surface raycast only. Make the dot's apparent size follow\n"
+                                      "its actual distance instead of the fixed reference distance.");
+                }
+                if (!distanceScaleAvailable) ImGui::EndDisabled();
             }
             ImGui::Separator();
 

--- a/src/Render/ColorBlit.cpp
+++ b/src/Render/ColorBlit.cpp
@@ -243,41 +243,100 @@ float4 PSMain(VSOut input) : SV_Target {
 )";
 
 
-// A single filled disc. Its own vertex shader, because the quad is positioned FROM the root
-// constants: that keeps the rasterised area down to the dot itself instead of the whole eye.
+// A radial laser spot generated entirely from SV_VertexID. This uses the same ring locations
+// and quantised vertex colours as the HMD ImGui mesh in OverlayDebugDraw, so the desktop
+// second-eye mirror retains the same source appearance.
 constexpr char kDotSource[] = R"(
 cbuffer DotParams : register(b0) {
     float2 centerNdc;    // -1..1, +Y up
-    float2 radiusNdc;    // half-extent per axis, already aspect-corrected by the caller
+    float2 radiusNdc;    // 2.5x-core halo extent, already aspect-corrected by the caller
     float4 color;        // straight alpha
 };
 
 struct VSOut {
     float4 position : SV_Position;
-    float2 local    : TEXCOORD0;   // -1..1 across the quad
+    float4 color    : COLOR0;
 };
 
-VSOut VSMain(uint vid : SV_VertexID) {
-    static const float2 corners[4] = {
-        float2(-1.0, -1.0), float2(-1.0, 1.0), float2(1.0, -1.0), float2(1.0, 1.0)
-    };
+static const uint kSegments = 64;
+static const uint kRingCount = 9;
+static const float kOuterCoreRatio = 2.5;
+static const float kRingCoreDistances[9] = {
+    0.25, 0.50, 0.75, 1.00, 1.30, 1.65, 2.00, 2.25, 2.50
+};
+
+float4 SpotColor(float coreDistance) {
+    const float intensity = exp(-0.69314718 * coreDistance * coreDistance);
+    const float outerFade = 1.0 - smoothstep(2.25, 2.5, coreDistance);
+    const float hotCore = exp(-4.0 * coreDistance * coreDistance);
+    const float3 hotColor = float3(1.0, 0.82, 0.68);
+    const float3 rgb = lerp(color.rgb, hotColor, hotCore);
+    // ImGui stores these samples as ImU32. Match that 8-bit quantisation before interpolation.
+    return round(saturate(float4(rgb, color.a * intensity * outerFade)) * 255.0) / 255.0;
+}
+
+float2 RingPoint(float coreDistance, uint segment) {
+    const float angle = 6.28318530718 * float(segment % kSegments) / float(kSegments);
+    const float radius = coreDistance / kOuterCoreRatio;
+    return float2(cos(angle), sin(angle)) * radius;
+}
+
+VSOut MakeVertex(float coreDistance, uint segment) {
     VSOut o;
-    o.local = corners[vid];
-    o.position = float4(centerNdc + corners[vid] * radiusNdc, 0.0, 1.0);
+    const float2 local = coreDistance > 0.0 ? RingPoint(coreDistance, segment) : float2(0.0, 0.0);
+    o.position = float4(centerNdc + local * radiusNdc, 0.0, 1.0);
+    o.color = SpotColor(coreDistance);
     return o;
 }
 
+VSOut VSMain(uint vid : SV_VertexID) {
+    const uint triangleIndex = vid / 3;
+    const uint corner = vid % 3;
+
+    // Center fan: center, first-ring current, first-ring next.
+    if (triangleIndex < kSegments) {
+        if (corner == 0) return MakeVertex(0.0, 0);
+        if (corner == 1) return MakeVertex(kRingCoreDistances[0], triangleIndex);
+        return MakeVertex(kRingCoreDistances[0], triangleIndex + 1);
+    }
+
+    // Every later band has two triangles per angular segment.
+    const uint bandTriangle = triangleIndex - kSegments;
+    const uint band = bandTriangle / (kSegments * 2);
+    const uint withinBand = bandTriangle % (kSegments * 2);
+    const uint segment = withinBand / 2;
+    const bool secondTriangle = (withinBand % 2) != 0;
+    const float innerDistance = kRingCoreDistances[band];
+    const float outerDistance = kRingCoreDistances[band + 1];
+
+    if (!secondTriangle) {
+        if (corner == 0) return MakeVertex(innerDistance, segment);
+        if (corner == 1) return MakeVertex(outerDistance, segment);
+        return MakeVertex(outerDistance, segment + 1);
+    }
+    if (corner == 0) return MakeVertex(innerDistance, segment);
+    if (corner == 1) return MakeVertex(outerDistance, segment + 1);
+    return MakeVertex(innerDistance, segment + 1);
+}
+
 float4 PSMain(VSOut i) : SV_Target {
-    const float d = length(i.local);
-    // One-pixel feather from the quad's own derivatives. Safe here in a way it was not in the
-    // sight shader: this pass runs on the finished image, after upscaling, so there is no
-    // sub-pixel jitter to make the derivative wobble frame to frame.
-    const float aa = max(fwidth(d), 1e-4);
-    const float cov = 1.0 - smoothstep(1.0 - aa, 1.0, d);
-    if (cov <= 0.0) discard;
-    return float4(color.rgb, color.a * cov);
+    return i.color;
 }
 )";
+
+constexpr UINT kDotMeshSegments = 64;
+constexpr UINT kDotMeshRings = 9;
+constexpr UINT kDotMeshVertexCount =
+    kDotMeshSegments * (1 + 2 * (kDotMeshRings - 1)) * 3;
+
+DXGI_FORMAT ToNonSrgbViewFormat(DXGI_FORMAT format) {
+    switch (format) {
+        case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB: return DXGI_FORMAT_R8G8B8A8_UNORM;
+        case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB: return DXGI_FORMAT_B8G8R8A8_UNORM;
+        case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB: return DXGI_FORMAT_B8G8R8X8_UNORM;
+        default: return format;
+    }
+}
 
 bool CompileShader(const char* src, const char* entry, const char* target, ComPtr<ID3DBlob>& out) {
     UINT flags = D3DCOMPILE_ENABLE_STRICTNESS;
@@ -582,6 +641,11 @@ bool ColorBlit::EnsureInitialized(ID3D12Device* device,
             dpso.pRootSignature = m_rootSigDot.Get();
             dpso.VS = { dvs->GetBufferPointer(), dvs->GetBufferSize() };
             dpso.PS = { dps->GetBufferPointer(), dps->GetBufferSize() };
+            // MAIN's ImGui dot is blended numerically into the game's UNORM backbuffer. The eye
+            // texture is typeless but its scene/HUD composite normally uses an sRGB RTV; reusing
+            // that view here would encode the faint halo after blending and make it much brighter
+            // than MAIN. Use the matching non-sRGB view only for this final dot pass.
+            dpso.RTVFormats[0] = ToNonSrgbViewFormat(colorFormat);
             auto& drt = dpso.BlendState.RenderTarget[0];
             drt.BlendEnable = TRUE;
             drt.SrcBlend = D3D12_BLEND_SRC_ALPHA;
@@ -592,7 +656,7 @@ bool ColorBlit::EnsureInitialized(ID3D12Device* device,
             drt.BlendOpAlpha = D3D12_BLEND_OP_ADD;
             drt.RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
             if (FAILED(device->CreateGraphicsPipelineState(&dpso, IID_PPV_ARGS(&m_psoDot)))) {
-                Log("ColorBlit: dot PSO create failed -- second eye stays dotless\n");
+                Log("ColorBlit: dot PSO create failed -- desktop second-eye mirror stays dotless\n");
                 m_psoDot.Reset();
             }
         } else {
@@ -622,7 +686,7 @@ bool ColorBlit::RecordDot(ID3D12GraphicsCommandList* cmdList,
     D3D12_CPU_DESCRIPTOR_HANDLE rtvCpu = m_rtvHeap->GetCPUDescriptorHandleForHeapStart();
     rtvCpu.ptr += static_cast<SIZE_T>(slot) * m_rtvStride;
     D3D12_RENDER_TARGET_VIEW_DESC rtv{};
-    rtv.Format = m_colorFormat;
+    rtv.Format = ToNonSrgbViewFormat(m_colorFormat);
     rtv.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
     m_device->CreateRenderTargetView(dstColor, &rtv, rtvCpu);
 
@@ -644,8 +708,8 @@ bool ColorBlit::RecordDot(ID3D12GraphicsCommandList* cmdList,
     cmdList->SetGraphicsRootSignature(m_rootSigDot.Get());
     cmdList->SetPipelineState(m_psoDot.Get());
     cmdList->SetGraphicsRoot32BitConstants(0, 8, k, 0);
-    cmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    cmdList->DrawInstanced(4, 1, 0, 0);
+    cmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmdList->DrawInstanced(kDotMeshVertexCount, 1, 0, 0);
     return true;
 }
 

--- a/src/Runtimes/OpenXRCapture.cpp
+++ b/src/Runtimes/OpenXRCapture.cpp
@@ -49,6 +49,7 @@ extern "C" float    CyberpunkVR_BarrelDotNdcY;
 extern "C" float    CyberpunkVR_BarrelDotRadiusPx;
 extern "C" unsigned long long CyberpunkVR_BarrelDotTick;
 extern "C" int      CyberpunkVR_BarrelDotSecondEye;
+extern "C" int      CyberpunkVR_BarrelDotSecondVisible;
 extern "C" unsigned long long CyberpunkVR_DebugBarrelDotDraws;
 extern "C" ID3D12Resource* CyberpunkVR_GetHudBlurTexture();
 extern "C" ID3D12Resource* CyberpunkVR_GetHudExposureBuffer();
@@ -966,6 +967,7 @@ bool OpenXRManager::CaptureMonoPresentedFrame(ID3D12Resource* backBuffer, const 
                     // dot in BOTH eyes the question stops being "does the right eye's reticle
                     // match the left eye's dot", which no one can judge across a fused pair.
                     if (vrcamEyeCaptured && CyberpunkVR_BarrelDotSecondEye &&
+                        CyberpunkVR_BarrelDotSecondVisible &&
                         CyberpunkVR_BarrelDotTick &&
                         GetTickCount64() - CyberpunkVR_BarrelDotTick < 250) {
                         if (m_colorBlit->RecordDot(m_captureCmdList, eyeSlotTex,

--- a/src/Runtimes/OpenXRCapture.cpp
+++ b/src/Runtimes/OpenXRCapture.cpp
@@ -40,17 +40,6 @@ extern "C" int CyberpunkVR_VisionFit;           // 1 = pixel-exact rather than s
 extern "C" float CyberpunkVR_VisionOffX;
 extern "C" float CyberpunkVR_VisionOffY;
 extern "C" unsigned long long CyberpunkVR_DebugVisionOverlays;
-// The barrel dot, published by the ImGui overlay (imgui_overlay.cpp) in NDC after its own zoom
-// compensation. Taking the finished number rather than re-projecting keeps the two eyes' dots
-// identical by construction.
-extern "C" float    CyberpunkVR_BarrelDotNdcX;
-extern "C" float    CyberpunkVR_BarrelDotNdcX2;   // the second eye's own value
-extern "C" float    CyberpunkVR_BarrelDotNdcY;
-extern "C" float    CyberpunkVR_BarrelDotRadiusPx;
-extern "C" unsigned long long CyberpunkVR_BarrelDotTick;
-extern "C" int      CyberpunkVR_BarrelDotSecondEye;
-extern "C" int      CyberpunkVR_BarrelDotSecondVisible;
-extern "C" unsigned long long CyberpunkVR_DebugBarrelDotDraws;
 extern "C" ID3D12Resource* CyberpunkVR_GetHudBlurTexture();
 extern "C" ID3D12Resource* CyberpunkVR_GetHudExposureBuffer();
 extern "C" ID3D12Resource* CyberpunkVR_GetFrameConstantBuffer();
@@ -960,28 +949,10 @@ bool OpenXRManager::CaptureMonoPresentedFrame(ID3D12Resource* backBuffer, const 
                         }
                     }
 
-                    // The barrel dot. Eye 0 gets it from the ImGui overlay on the backbuffer;
-                    // this is the same point, at the same NDC, stamped into eye 1. It is a
-                    // feature (the dot was simply missing on this side) and it is also the
-                    // instrument that settles where the sight's reticle really points: with a
-                    // dot in BOTH eyes the question stops being "does the right eye's reticle
-                    // match the left eye's dot", which no one can judge across a fused pair.
-                    if (vrcamEyeCaptured && CyberpunkVR_BarrelDotSecondEye &&
-                        CyberpunkVR_BarrelDotSecondVisible &&
-                        CyberpunkVR_BarrelDotTick &&
-                        GetTickCount64() - CyberpunkVR_BarrelDotTick < 250) {
-                        if (m_colorBlit->RecordDot(m_captureCmdList, eyeSlotTex,
-                                                   CyberpunkVR_BarrelDotNdcX2,
-                                                   CyberpunkVR_BarrelDotNdcY,
-                                                   CyberpunkVR_BarrelDotRadiusPx,
-                                                   1.0f, 0.045f, 0.045f, 1.0f))
-                            ++CyberpunkVR_DebugBarrelDotDraws;
-                    }
-
                     // AND THE OVERLAY ITSELF -- the F10 menu and the mouse cursor, which live in
                     // MAIN's backbuffer because that is where ImGui draws, and were therefore absent
-                    // from this eye entirely. Recorded LAST, so the UI sits on top of the HUD, the
-                    // scanner outline and the dot, exactly as it does on the flat screen.
+                    // from this eye entirely. Its dedicated second-eye world list also carries the
+                    // barrel dot, below the UI but above the HUD and scanner outline.
                     //
                     // The distance knob is the same idea as CyberpunkVR_HudDistanceM and defaults to
                     // the same 0: only this eye can move, so the whole disparity goes here, and the

--- a/src/Stereo/Mirror.cpp
+++ b/src/Stereo/Mirror.cpp
@@ -220,7 +220,8 @@ void d12_submit_mirror_copy(ID3D12CommandQueue* queue) {
         // The barrel dot, at the same NDC the overlay drew it at on the backbuffer. The mirror
         // window IS the desk-side view of eye 1, so without this the dot is invisible whenever
         // there is no headset session -- which is most of the time while working on it.
-        if (hud_composited && CyberpunkVR_BarrelDotSecondEye && CyberpunkVR_BarrelDotTick &&
+        if (hud_composited && CyberpunkVR_BarrelDotSecondEye &&
+            CyberpunkVR_BarrelDotSecondVisible && CyberpunkVR_BarrelDotTick &&
             GetTickCount64() - CyberpunkVR_BarrelDotTick < 250) {
             if (g_hud_mirror_blit.RecordDot(g_d12_copy_list, g_d12_mtex,
                                             CyberpunkVR_BarrelDotNdcX2,


### PR DESCRIPTION
This PR implements #64 and builds on the raycast laser-dot work already submitted in #60.

The first three commits are the same commits from #60. The new work in this PR is contained in the two commits after them:

1. **Pretty, distance-scaled laser dot**

   * Replaces the simple dot with a brighter core and soft radial halo, making it look much closer to a real laser dot in VR.
   * Uses the same ImGui radial rendering for both eyes so the appearance is consistent in stereo.
   * Adds an adjustable base size in the F10 settings.
   * Uses projection-based sizing instead of a fixed pixel radius, so the apparent size is more consistent across different VR resolutions and FOVs.
   * Adds optional distance scaling for **Surface raycast** mode, using the actual raycast hit distance.
   * Keeps a small infinity marker when Surface raycast has no valid hit.

2. **NPC self-occlusion fix**

   * Tracks which NPC was selected by the muzzle raycast.
   * Prevents that same NPC from incorrectly occluding its own laser dot during the per-eye LOS check.
   * Other NPCs and world geometry still occlude the dot normally.

The distance-scaling part depends on the Surface raycast feature from #60. Without a valid surface hit, the improved dot rendering still works, but it cannot scale from the actual surface distance.

Both changes have been tested in HMD, including near/far surfaces, raycast hit/miss transitions, stereo rendering, and NPC occlusion.
