### PR TITLE
F10: center picture box on lens optical center, slider reset/keyboard tweak, fix runtime FOV toggle restore

### DIFF
--- a/include/Core/LiveControls.hpp
+++ b/include/Core/LiveControls.hpp
@@ -77,6 +77,11 @@ struct LiveControls {
     volatile int xrVehicleGunTrigger;   // 1 (default) = with a weapon out in the driver seat the right trigger FIRES (pad RB) and the throttle is latched.
     volatile float xrVehicleThrottleTrim; // how much of the throttle's full travel the left stick adds or removes per second while a weapon is out. Default 0.5.
     volatile int xrPhysicalBodyRotation; // 1 = physical body rotation (avatar body follows HMD/aim heading). 0 (default) = classic stick/snap heading. Gates the aiming/weapon body-turn paths; vehicles unaffected.
+    // Center box on lens: pitch/yaw on camera + submit together (no FOV change).
+    // 0 (default) = off. Opt-in because canted-optics correction is headset-specific.
+    volatile int xrLensBoxCenter;
+    volatile float xrViewBoxPitchDeg;
+    volatile float xrViewBoxYawDeg;
 };
 
 extern LiveControls g_liveControls;

--- a/include/Overlay/LiveControlsUi.hpp
+++ b/include/Overlay/LiveControlsUi.hpp
@@ -97,6 +97,9 @@ struct LiveControlsUiState {
     // xrVehicleThrottleTrim of full travel per second.
     int xrVehicleGunTrigger;
     float xrVehicleThrottleTrim;
+    int xrLensBoxCenter;
+    float xrViewBoxPitchDeg;
+    float xrViewBoxYawDeg;
 };
 
 // Read-only snapshot for the compact ADS-camera diagnostic (dabinn, TofuExpress f8a827eb).

--- a/include/Runtimes/OpenXRManager.hpp
+++ b/include/Runtimes/OpenXRManager.hpp
@@ -800,7 +800,12 @@ public:
     void MaybeLogRuntimeFovDetails(const XrFovf& left, const XrFovf& right, float runtimeHfovDeg, float runtimeVfovDeg, float runtimeIpdMeters);
     bool GetCurrentEyeCenterOffset(int eye, XrVector3f* out);
     bool GetCurrentEyeFov(int eye, XrFovf* out);
-    
+    // Pitch/yaw (radians) for "Center box on lens". Camera + submit, no FOV change.
+    float GetViewBoxPitchRad();
+    float GetViewBoxYawRad();
+    float GetViewBoxManualSlideRad();
+    float GetViewBoxManualYawRad();
+    void ApplyViewBoxPitch(OpenXRHeadPose* pose);
     bool GetRecommendedRenderTargetSize(uint32_t* width, uint32_t* height) const;
 
     bool IsInitialized() const { return m_initialized; }

--- a/include/Runtimes/RuntimeFovCorrection.hpp
+++ b/include/Runtimes/RuntimeFovCorrection.hpp
@@ -61,6 +61,20 @@ inline float GetCorrectedGameHorizontalFovDeg(const RuntimeFovCorrection& corr) 
     return ((h0 + h1) * 0.5f) * (180.0f / 3.1415926535f);
 }
 
+// Optical centre of the lens FOV relative to the view-pose forward axis, radians.
+// Quest 3 ~+44/-55 -> about -5.5 deg (centre sits BELOW head-forward). A symmetric
+// render/submit about head-forward therefore clips the top of the image "box" and
+// leaves a visible bottom edge -- exactly the canted-panel symptom.
+inline float GetLensVerticalCenterRad(const XrFovf& left, const XrFovf& right) {
+    return 0.25f * (left.angleUp + left.angleDown + right.angleUp + right.angleDown);
+}
+
+// Horizontal counterpart of GetLensVerticalCenterRad. On Quest 3 the two eyes cant
+// outward in opposite directions, so the average is often near zero -- useful mainly
+// as a per-headset curiosity; manual yaw fine-tune is the practical control.
+inline float GetLensHorizontalCenterRad(const XrFovf& left, const XrFovf& right) {
+    return 0.25f * (left.angleLeft + left.angleRight + right.angleLeft + right.angleRight);
+}
 // From PR #24 (DeniDoman), ported unchanged in substance from 0.1.1. The measurements in these
 // comments are the author's, on a Quest 3 over both VDXR and SteamVR -- hardware not available here,
 // so they are kept verbatim rather than paraphrased.

--- a/src/Core/LauncherConfig.cpp
+++ b/src/Core/LauncherConfig.cpp
@@ -108,6 +108,12 @@ void InitRuntimePaths() {
     g_liveControls.xrXInputInstall = 1;
     g_liveControls.xrInputActions = 1;
 
+    // Off until the user opts in: Quest 3 canted optics are the reason this exists,
+    // and a default-on correction on a symmetric headset is a surprise, not a feature.
+    g_liveControls.xrLensBoxCenter = 0;
+    g_liveControls.xrViewBoxPitchDeg = 0.0f;
+    g_liveControls.xrViewBoxYawDeg = 0.0f;
+
     // Capture the recenter-request baseline NOW (before CET could write), so the
     // first OnGameAttached this session is seen as a change and triggers a recenter,
     // while a stale counter left over from a previous session does not.
@@ -192,6 +198,9 @@ void EnsureLiveControlFileExists() {
     fprintf(file, "xr_mono_xqueue_wait=0\n");
     fprintf(file, "xr_snap_turn_pulse_ms=30\n");
     fprintf(file, "xr_mono_depth_capture=1\n");
+    fprintf(file, "xr_lens_box_center=0\n");
+    fprintf(file, "xr_view_box_pitch_deg=0.0\n");
+    fprintf(file, "xr_view_box_yaw_deg=0.0\n");
     fclose(file);
 }
 

--- a/src/Core/LiveControlsPoll.cpp
+++ b/src/Core/LiveControlsPoll.cpp
@@ -240,6 +240,9 @@ void PollLiveControls() {
     float xrWheelHornRadius = g_liveControls.xrWheelHornRadius > 0.0f ? g_liveControls.xrWheelHornRadius : 0.12f;
     int xrVehicleGunTrigger = g_liveControls.xrVehicleGunTrigger;
     float xrVehicleThrottleTrim = g_liveControls.xrVehicleThrottleTrim > 0.0f ? g_liveControls.xrVehicleThrottleTrim : 0.5f;
+    int xrLensBoxCenter = 0;
+    float xrViewBoxPitchDeg = 0.0f;
+    float xrViewBoxYawDeg = 0.0f;
 
     FILE* file = _fsopen(g_liveControlPath, "r", _SH_DENYNO);
     if (!file) return;
@@ -578,6 +581,21 @@ void PollLiveControls() {
             xrVehicleThrottleTrim = value;
             continue;
         }
+        if (sscanf_s(line, "xr_lens_box_center=%d", &intValue) == 1 ||
+            sscanf_s(line, "xr_lens_box_center = %d", &intValue) == 1) {
+            xrLensBoxCenter = intValue != 0 ? 1 : 0;
+            continue;
+        }
+        if (sscanf_s(line, "xr_view_box_pitch_deg=%f", &value) == 1 ||
+            sscanf_s(line, "xr_view_box_pitch_deg = %f", &value) == 1) {
+            xrViewBoxPitchDeg = value;
+            continue;
+        }
+        if (sscanf_s(line, "xr_view_box_yaw_deg=%f", &value) == 1 ||
+            sscanf_s(line, "xr_view_box_yaw_deg = %f", &value) == 1) {
+            xrViewBoxYawDeg = value;
+            continue;
+        }
 
     }
     fclose(file);
@@ -676,6 +694,11 @@ void PollLiveControls() {
     g_liveControls.xrVehicleGunTrigger = xrVehicleGunTrigger != 0 ? 1 : 0;
     g_liveControls.xrVehicleThrottleTrim = (xrVehicleThrottleTrim < 0.05f) ? 0.05f
                                          : (xrVehicleThrottleTrim > 3.0f ? 3.0f : xrVehicleThrottleTrim);
+    g_liveControls.xrLensBoxCenter = xrLensBoxCenter != 0 ? 1 : 0;
+    g_liveControls.xrViewBoxPitchDeg =
+        (xrViewBoxPitchDeg < -30.0f) ? -30.0f : (xrViewBoxPitchDeg > 30.0f ? 30.0f : xrViewBoxPitchDeg);
+    g_liveControls.xrViewBoxYawDeg =
+        (xrViewBoxYawDeg < -30.0f) ? -30.0f : (xrViewBoxYawDeg > 30.0f ? 30.0f : xrViewBoxYawDeg);
     SetHmdTrackingSmooth(xrHmdSmooth);
     CyberpunkVR_HandLerpSpeed = (xrHandLerp < 0.0f) ? 0.0f : ((xrHandLerp > 30.0f) ? 30.0f : xrHandLerp);
     // Clamped rather than trusted: at 0 the hold can never be offered and at a third of a metre it is
@@ -790,6 +813,9 @@ LiveControlsUiState MakeLiveControlsUiState() {
     state.xrWheelHornRadius = g_liveControls.xrWheelHornRadius;
     state.xrVehicleGunTrigger = g_liveControls.xrVehicleGunTrigger;
     state.xrVehicleThrottleTrim = g_liveControls.xrVehicleThrottleTrim;
+    state.xrLensBoxCenter = g_liveControls.xrLensBoxCenter;
+    state.xrViewBoxPitchDeg = g_liveControls.xrViewBoxPitchDeg;
+    state.xrViewBoxYawDeg = g_liveControls.xrViewBoxYawDeg;
     return state;
 }
 
@@ -875,6 +901,11 @@ void PersistLiveControlsUiState(const LiveControlsUiState& state) {
     fprintf(file, "xr_wheel_horn_radius=%.3f\n", state.xrWheelHornRadius > 0.0f ? state.xrWheelHornRadius : 0.12f);
     fprintf(file, "xr_vehicle_gun_trigger=%d\n", state.xrVehicleGunTrigger != 0 ? 1 : 0);
     fprintf(file, "xr_vehicle_throttle_trim=%.2f\n", state.xrVehicleThrottleTrim > 0.0f ? state.xrVehicleThrottleTrim : 0.5f);
+    fprintf(file, "xr_lens_box_center=%d\n", state.xrLensBoxCenter != 0 ? 1 : 0);
+    fprintf(file, "xr_view_box_pitch_deg=%.3f\n",
+        (state.xrViewBoxPitchDeg < -30.0f) ? -30.0f : (state.xrViewBoxPitchDeg > 30.0f ? 30.0f : state.xrViewBoxPitchDeg));
+    fprintf(file, "xr_view_box_yaw_deg=%.3f\n",
+        (state.xrViewBoxYawDeg < -30.0f) ? -30.0f : (state.xrViewBoxYawDeg > 30.0f ? 30.0f : state.xrViewBoxYawDeg));
     fclose(file);
 
     WIN32_FILE_ATTRIBUTE_DATA fileData;
@@ -965,6 +996,13 @@ extern "C" void SetLiveControlsUiState(const LiveControlsUiState* state, int per
         const float tt = state->xrVehicleThrottleTrim;
         g_liveControls.xrVehicleThrottleTrim = (tt < 0.05f) ? 0.05f : (tt > 3.0f ? 3.0f : tt);
     }
+    g_liveControls.xrLensBoxCenter = state->xrLensBoxCenter != 0 ? 1 : 0;
+    g_liveControls.xrViewBoxPitchDeg =
+        (state->xrViewBoxPitchDeg < -30.0f) ? -30.0f
+        : (state->xrViewBoxPitchDeg > 30.0f ? 30.0f : state->xrViewBoxPitchDeg);
+    g_liveControls.xrViewBoxYawDeg =
+        (state->xrViewBoxYawDeg < -30.0f) ? -30.0f
+        : (state->xrViewBoxYawDeg > 30.0f ? 30.0f : state->xrViewBoxYawDeg);
     WriteVrikSettingsFile(); // publish mouse-Y flag for the CET VRIK mod
 
     if (prevMono != g_liveControls.xrMonoSubmit) {

--- a/src/Hooks/LocateCamera.cpp
+++ b/src/Hooks/LocateCamera.cpp
@@ -496,6 +496,7 @@ extern "C" void __fastcall OnLocateCameraCallback(float* rbxPtr, float xmm0_val)
         : OpenXRManager::Get().GetHeadPose(&xrPose);
     const bool composeAtWrite = (CyberpunkVR_CamWriteInPatch && CyberpunkVR_CamComposeAtWrite);
     if (hasXR) {
+        OpenXRManager::Get().ApplyViewBoxPitch(&xrPose);
         // Hand the EXACT sample this frame's camera is built from to the submit path, so
         // the image is labelled with the pose it was rendered from instead of whatever the
         // pose cache holds by the time it reaches Present. See SetPendingRenderHeadPose.

--- a/src/Hooks/PatchCamera.cpp
+++ b/src/Hooks/PatchCamera.cpp
@@ -296,6 +296,7 @@ extern "C" void __fastcall OnPatchCameraCallback(float* cameraState, void* owner
                     if (got) ++CyberpunkVR_DebugPoseFromCache;
                 }
                 if (got) {
+                    OpenXRManager::Get().ApplyViewBoxPitch(&p);
                     // THE HEADING OF THIS FRAME, NOT OF THE PREVIOUS ONE.
                     //
                     // g_headingSy/Cy are published by LocateCamera, and LocateCamera runs INSIDE the

--- a/src/Overlay/OverlayPanels.cpp
+++ b/src/Overlay/OverlayPanels.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <imgui_impl_dx12.h>
 #include <imgui_impl_win32.h>
 #include "im3d.h"
@@ -107,11 +108,121 @@ bool InputIntClamped(const char* label, int* value, int minValue, int maxValue) 
     return changed;
 }
 
+static constexpr float kSliderArrowStep = 0.1f;
+
+static void DrawResetArrowIcon(ImDrawList* drawList, ImVec2 center, float radius, ImU32 color) {
+    // Counter-clockwise circular arrow (ReShade-style undo), Y-down screen space.
+    const float thickness = (1.5f > radius * 0.32f) ? 1.5f : (radius * 0.32f);
+    const float a0 = -IM_PI * 0.15f;
+    const float sweep = IM_PI * 1.65f;
+    const int segs = 16;
+    ImVec2 prev(center.x + cosf(a0) * radius, center.y + sinf(a0) * radius);
+    for (int i = 1; i <= segs; ++i) {
+        const float a = a0 - sweep * (static_cast<float>(i) / static_cast<float>(segs));
+        const ImVec2 p(center.x + cosf(a) * radius, center.y + sinf(a) * radius);
+        drawList->AddLine(prev, p, color, thickness);
+        prev = p;
+    }
+    const float tipA = a0 - sweep;
+    const ImVec2 tip(center.x + cosf(tipA) * radius, center.y + sinf(tipA) * radius);
+    const float tx = sinf(tipA);
+    const float ty = -cosf(tipA);
+    const float nx = -ty;
+    const float ny = tx;
+    const float head = radius * 0.72f;
+    drawList->AddTriangleFilled(
+        ImVec2(tip.x + tx * head * 0.15f, tip.y + ty * head * 0.15f),
+        ImVec2(tip.x - tx * head + nx * head * 0.42f, tip.y - ty * head + ny * head * 0.42f),
+        ImVec2(tip.x - tx * head - nx * head * 0.42f, tip.y - ty * head - ny * head * 0.42f),
+        color);
+}
+
+static bool ResetToDefaultButton(const char* id) {
+    const float size = ImGui::GetFrameHeight();
+    ImGui::PushID(id);
+    ImGui::PushItemFlag(ImGuiItemFlags_NoNav, true);
+    const bool pressed = ImGui::InvisibleButton("##reset", ImVec2(size, size));
+    ImGui::PopItemFlag();
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    const bool hovered = ImGui::IsItemHovered();
+    const ImU32 bg = hovered ? IM_COL32(48, 48, 48, 255) : IM_COL32(28, 28, 28, 255);
+    const ImU32 border = IM_COL32(64, 64, 64, 255);
+    drawList->AddRectFilled(min, max, bg, 2.0f);
+    drawList->AddRect(min, max, border, 2.0f);
+    const ImVec2 center((min.x + max.x) * 0.5f, (min.y + max.y) * 0.5f);
+    DrawResetArrowIcon(drawList, center, size * 0.28f, IM_COL32(255, 255, 255, 255));
+    if (hovered) {
+        ImGui::SetTooltip("Reset to default");
+    }
+    ImGui::PopID();
+    return pressed;
+}
+
+static bool ApplySliderArrowStep(float* value, float minValue, float maxValue) {
+    if (!ImGui::IsItemFocused() || ImGui::IsItemActive()) {
+        return false;
+    }
+    float delta = 0.0f;
+    if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow, true) ||
+        ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft, true)) {
+        delta = -kSliderArrowStep;
+    } else if (ImGui::IsKeyPressed(ImGuiKey_RightArrow, true) ||
+               ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight, true)) {
+        delta = kSliderArrowStep;
+    } else {
+        return false;
+    }
+    ImGui::NavMoveRequestCancel();
+    const float next = std::clamp(*value + delta, minValue, maxValue);
+    if (next == *value) {
+        return false;
+    }
+    *value = next;
+    return true;
+}
+
+bool SliderFloatReset(const char* label, float* value, float minValue, float maxValue,
+                      const char* format, float defaultValue) {
+    const float resetW = ImGui::GetFrameHeight();
+    const float gap = ImGui::GetStyle().ItemInnerSpacing.x;
+    float sliderW = ImGui::CalcItemWidth() - resetW - gap;
+    if (sliderW < 80.0f) {
+        sliderW = 80.0f;
+    }
+    ImGui::SetNextItemWidth(sliderW);
+    bool changed = ImGui::SliderFloat(label, value, minValue, maxValue, format);
+    changed |= ApplySliderArrowStep(value, minValue, maxValue);
+    ImGui::SameLine(0.0f, gap);
+    if (ResetToDefaultButton(label)) {
+        if (*value != defaultValue) {
+            *value = std::clamp(defaultValue, minValue, maxValue);
+            changed = true;
+        }
+    }
+    return changed;
+}
+
 bool DrawFovControl(LiveControlsUiState& state) {
     bool changed = false;
+    // Last non-zero (manual) FOV for this session. Checking the runtime box must not
+    // throw it away, so unchecking restores 86 instead of snapping back to 112.
+    static float s_savedManualFov = 0.0f;
+    if (state.xrForceFov > 0.0f) {
+        s_savedManualFov = state.xrForceFov;
+    }
+
     bool useRuntime = state.xrForceFov <= 0.0f;
     if (ImGui::Checkbox("Use OpenXR runtime projection FOV", &useRuntime)) {
-        state.xrForceFov = useRuntime ? 0.0f : 112.0f;
+        if (useRuntime) {
+            if (state.xrForceFov > 0.0f) {
+                s_savedManualFov = state.xrForceFov;
+            }
+            state.xrForceFov = 0.0f;
+        } else {
+            state.xrForceFov = (s_savedManualFov > 0.0f) ? s_savedManualFov : 112.0f;
+        }
         changed = true;
     }
 
@@ -119,8 +230,10 @@ bool DrawFovControl(LiveControlsUiState& state) {
         ImGui::BeginDisabled();
     }
     float fov = state.xrForceFov <= 0.0f ? 112.0f : state.xrForceFov;
-    if (ImGui::SliderFloat("OpenXR projection layer FOV", &fov, 80.0f, 140.0f, "%.1f deg")) {
+    if (SliderFloatReset("OpenXR projection layer FOV", &fov, 80.0f, 140.0f, "%.1f deg", 112.0f)
+        && !useRuntime) {
         state.xrForceFov = fov;
+        s_savedManualFov = fov;
         changed = true;
     }
     if (useRuntime) {
@@ -205,7 +318,7 @@ void DrawVRHandsControls() {
         // The one number the feature has. Everything else -- the rate, when it starts, when it stops --
         // follows from it: whatever is outside the cone is asked for in the frame it appears.
         float cone = CyberpunkVR_BodyYawFollowDeadDeg;
-        if (ImGui::SliderFloat("Free-look cone", &cone, 0.0f, 60.0f, "%.0f deg")) {
+        if (SliderFloatReset("Free-look cone", &cone, 0.0f, 60.0f, "%.0f deg", 25.0f)) {
             CyberpunkVR_BodyYawFollowDeadDeg = cone;
         }
         if (ImGui::IsItemHovered()) {
@@ -243,23 +356,23 @@ void DrawVRHandsControls() {
     }
 
     bool calChanged = false;
-    calChanged |= ImGui::SliderFloat("Reach scale R", &scaleR, 0.80f, 1.30f, "%.3f");
-    calChanged |= ImGui::SliderFloat("Reach scale L", &scaleL, 0.80f, 1.30f, "%.3f");
-    calChanged |= ImGui::SliderFloat("Height R", &heightR, -0.20f, 0.50f, "%.3f m");
-    calChanged |= ImGui::SliderFloat("Height L", &heightL, -0.20f, 0.50f, "%.3f m");
-    calChanged |= ImGui::SliderFloat("Elbow swing R", &swingR, -3.0f, 3.0f, "%.2f");
-    calChanged |= ImGui::SliderFloat("Elbow swing L", &swingL, -3.0f, 3.0f, "%.2f");
-    calChanged |= ImGui::SliderFloat("Elbow pole R", &poleR, -180.0f, 180.0f, "%.1f deg");
-    calChanged |= ImGui::SliderFloat("Elbow pole L", &poleL, -180.0f, 180.0f, "%.1f deg");
+    calChanged |= SliderFloatReset("Reach scale R", &scaleR, 0.80f, 1.30f, "%.3f", 1.05f);
+    calChanged |= SliderFloatReset("Reach scale L", &scaleL, 0.80f, 1.30f, "%.3f", 1.06f);
+    calChanged |= SliderFloatReset("Height R", &heightR, -0.20f, 0.50f, "%.3f m", 0.0f);
+    calChanged |= SliderFloatReset("Height L", &heightL, -0.20f, 0.50f, "%.3f m", 0.0f);
+    calChanged |= SliderFloatReset("Elbow swing R", &swingR, -3.0f, 3.0f, "%.2f", 1.0f);
+    calChanged |= SliderFloatReset("Elbow swing L", &swingL, -3.0f, 3.0f, "%.2f", 1.0f);
+    calChanged |= SliderFloatReset("Elbow pole R", &poleR, -180.0f, 180.0f, "%.1f deg", 0.0f);
+    calChanged |= SliderFloatReset("Elbow pole L", &poleL, -180.0f, 180.0f, "%.1f deg", 0.0f);
 
     ImGui::Separator();
     ImGui::TextUnformatted("Wrist rotation offset (palm/finger alignment, deg)");
-    calChanged |= ImGui::SliderFloat("Wrist R pitch", &wRp, -180.0f, 180.0f, "%.1f");
-    calChanged |= ImGui::SliderFloat("Wrist R yaw",   &wRy, -180.0f, 180.0f, "%.1f");
-    calChanged |= ImGui::SliderFloat("Wrist R roll",  &wRr, -180.0f, 180.0f, "%.1f");
-    calChanged |= ImGui::SliderFloat("Wrist L pitch", &wLp, -180.0f, 180.0f, "%.1f");
-    calChanged |= ImGui::SliderFloat("Wrist L yaw",   &wLy, -180.0f, 180.0f, "%.1f");
-    calChanged |= ImGui::SliderFloat("Wrist L roll",  &wLr, -180.0f, 180.0f, "%.1f");
+    calChanged |= SliderFloatReset("Wrist R pitch", &wRp, -180.0f, 180.0f, "%.1f", 0.0f);
+    calChanged |= SliderFloatReset("Wrist R yaw",   &wRy, -180.0f, 180.0f, "%.1f", -90.0f);
+    calChanged |= SliderFloatReset("Wrist R roll",  &wRr, -180.0f, 180.0f, "%.1f", 0.0f);
+    calChanged |= SliderFloatReset("Wrist L pitch", &wLp, -180.0f, 180.0f, "%.1f", -180.0f);
+    calChanged |= SliderFloatReset("Wrist L yaw",   &wLy, -180.0f, 180.0f, "%.1f", -90.0f);
+    calChanged |= SliderFloatReset("Wrist L roll",  &wLr, -180.0f, 180.0f, "%.1f", 0.0f);
 
     ImGui::Separator();
     // Auto-calibration: T-pose sample from the same controller poses that draw the gizmo hands.
@@ -510,8 +623,8 @@ void DrawStereoControls() {
         }
         if (g_showCompactAdsTelemetry) {
             ImGui::Indent();
-            ImGui::SliderFloat("Telemetry X", &g_compactAdsTelemetryX, 0.10f, 0.90f, "%.2f");
-            ImGui::SliderFloat("Telemetry Y", &g_compactAdsTelemetryY, 0.10f, 0.90f, "%.2f");
+            SliderFloatReset("Telemetry X", &g_compactAdsTelemetryX, 0.10f, 0.90f, "%.2f", 0.57f);
+            SliderFloatReset("Telemetry Y", &g_compactAdsTelemetryY, 0.10f, 0.90f, "%.2f", 0.30f);
             ImGui::TextDisabled("Normalised position in the eye image");
             ImGui::Unindent();
         }
@@ -573,17 +686,17 @@ bool DrawLiveControls(LiveControlsUiState& state) {
             if (ImGui::CollapsingHeader("View / Resolution", ImGuiTreeNodeFlags_DefaultOpen)) {
                 changed |= DrawFovControl(state);
                 changed |= CheckboxInt("VR menu quad", &state.xrMenuRect);
-                changed |= ImGui::SliderFloat("VR menu FOV", &state.xrMenuFov, 30.0f, 120.0f, "%.1f deg");
+                changed |= SliderFloatReset("VR menu FOV", &state.xrMenuFov, 30.0f, 120.0f, "%.1f deg", 65.0f);
             }
 
             if (ImGui::CollapsingHeader("Stereo", ImGuiTreeNodeFlags_DefaultOpen)) {
-        changed |= ImGui::SliderFloat("Motion prediction (ms)", &state.xrMotionPredictMs, 0.0f, 60.0f, "%.1f ms");
+        changed |= SliderFloatReset("Motion prediction (ms)", &state.xrMotionPredictMs, 0.0f, 60.0f, "%.1f ms", 0.0f);
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Forward-predicts the head pose by this many ms using head\n"
                               "velocity, hiding render-to-photon latency. 0 = off.\n"
                               "Tune up until motion feels responsive without overshoot.");
         }
-        changed |= ImGui::SliderFloat("Stereo separation x", &state.xrStereoScale, 0.25f, 5.0f, "%.2fx");
+        changed |= SliderFloatReset("Stereo separation x", &state.xrStereoScale, 0.25f, 5.0f, "%.2fx", 1.0f);
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Personal fine-tune on the auto IPD. 1.0 = calibrated natural\n"
                               "separation, auto-scaled to the headset's runtime IPD. Nudge\n"
@@ -591,14 +704,14 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                               "the eye alternation obvious on the flat monitor for testing.");
         }
         // ── World scale + honest IPD ──
-        changed |= ImGui::SliderFloat("World scale", &state.xrWorldScale, 0.20f, 3.0f, "%.2f");
+        changed |= SliderFloatReset("World scale", &state.xrWorldScale, 0.20f, 3.0f, "%.2f", 1.0f);
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Scales eye separation AND head translation together.\n"
                               "Lower it (e.g. 0.8) to make the world look\n"
                               "BIGGER / yourself smaller; raise to shrink the world. Use this if V\n"
                               "and NPCs feel too large.");
         }
-        changed |= ImGui::SliderFloat("IPD scale", &state.xrIpdScale, 0.50f, 2.0f, "%.2fx");
+        changed |= SliderFloatReset("IPD scale", &state.xrIpdScale, 0.50f, 2.0f, "%.2fx", 1.0f);
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Eye-separation multiplier on the runtime IPD. 1.0 = the neutral\n"
                               "baseline (+-0.033 m on a typical headset).\n"
@@ -631,9 +744,36 @@ bool DrawLiveControls(LiveControlsUiState& state) {
         // head translation -- it dropped these three offsets and the calibration bakes with it,
         // then hid the very sliders that were needed to put the view right. The offsets are
         // always live now, and they reach BOTH eyes.
-        changed |= ImGui::SliderFloat("Head X right", &state.xrHeadOffsetX, -0.50f, 0.50f, "%.3f m");
-        changed |= ImGui::SliderFloat("Head Y forward", &state.xrHeadOffsetY, -0.50f, 0.50f, "%.3f m");
-        changed |= ImGui::SliderFloat("Head Z up", &state.xrHeadOffsetZ, -0.50f, 0.50f, "%.3f m");
+        changed |= SliderFloatReset("Head X right", &state.xrHeadOffsetX, -0.50f, 0.50f, "%.3f m", 0.0f);
+        changed |= SliderFloatReset("Head Y forward", &state.xrHeadOffsetY, -0.50f, 0.50f, "%.3f m", 0.0f);
+        changed |= SliderFloatReset("Head Z up", &state.xrHeadOffsetZ, -0.50f, 0.50f, "%.3f m", 0.0f);
+
+        ImGui::Separator();
+        ImGui::TextUnformatted("HMD picture box");
+        ImGui::TextWrapped("Centers the rendered image on the headset's lens optical centre "
+            "(important on canted optics such as Quest 3). Use the sliders below "
+            "to fine-tune vertical and horizontal position.");
+        {
+            int boxCenter = state.xrLensBoxCenter != 0 ? 1 : 0;
+            if (CheckboxInt("Center box on lens", &boxCenter)) {
+                state.xrLensBoxCenter = boxCenter;
+                changed = true;
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Aligns the full picture box with the lens optical centre.\n"
+                    "Applied to the render camera and the submit pose together.");
+            }
+            changed |= SliderFloatReset("Box vertical (deg)", &state.xrViewBoxPitchDeg, -15.0f, 15.0f, "%.2f", 0.0f);
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Move the picture box up or down.\n"
+                    "Positive = down. Negative = up.");
+            }
+            changed |= SliderFloatReset("Box horizontal (deg)", &state.xrViewBoxYawDeg, -15.0f, 15.0f, "%.2f", 0.0f);
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Move the picture box left or right.\n"
+                    "Positive = right. Negative = left.");
+            }
+        }
 
         ImGui::Separator();
         ImGui::TextUnformatted("In a vehicle only (added on top of the Head sliders)");
@@ -647,9 +787,9 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                 "ignored the moment you step out, so the car and the street can be tuned\n"
                 "separately. Zero = the car keeps exactly the offset it has today.");
         }
-        changed |= ImGui::SliderFloat("Car Head X right", &state.xrVehHeadOffsetX, -0.50f, 0.50f, "%.3f m");
-        changed |= ImGui::SliderFloat("Car Head Y forward", &state.xrVehHeadOffsetY, -0.50f, 0.50f, "%.3f m");
-        changed |= ImGui::SliderFloat("Car Head Z up", &state.xrVehHeadOffsetZ, -0.50f, 0.50f, "%.3f m");
+        changed |= SliderFloatReset("Car Head X right", &state.xrVehHeadOffsetX, -0.50f, 0.50f, "%.3f m", 0.0f);
+        changed |= SliderFloatReset("Car Head Y forward", &state.xrVehHeadOffsetY, -0.50f, 0.50f, "%.3f m", 0.0f);
+        changed |= SliderFloatReset("Car Head Z up", &state.xrVehHeadOffsetZ, -0.50f, 0.50f, "%.3f m", 0.0f);
         {   // Live, so a slider that is doing nothing says so instead of being blamed.
             ImGui::TextDisabled(g_isInVehicle ? "   (in a vehicle: these are live)"
                                               : "   (on foot: these are ignored)");
@@ -661,7 +801,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                 ImGui::Checkbox("Enable hand overlay", &g_drawHandLocator);
                 ImGui::Checkbox("Draw 3D hand proxy", &g_drawHandProxy3D);
                 ImGui::Checkbox("Draw debug wire/axes", &g_drawHandDebugAxes);
-                ImGui::SliderFloat("Locator scale", &g_handLocatorScale, 0.50f, 2.00f, "%.2f");
+                SliderFloatReset("Locator scale", &g_handLocatorScale, 0.50f, 2.00f, "%.2f", 1.0f);
             }
 
             if (ImGui::CollapsingHeader("DLSS / Debug")) {
@@ -739,7 +879,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
             }
             {
                 float r = state.xrWheelRadius > 0.0f ? state.xrWheelRadius : 0.28f;
-                if (ImGui::SliderFloat("Grab radius (m)", &r, 0.08f, 0.60f, "%.2f")) {
+                if (SliderFloatReset("Grab radius (m)", &r, 0.08f, 0.60f, "%.2f", 0.28f)) {
                     state.xrWheelRadius = r;
                     changed = true;
                 }
@@ -749,7 +889,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                                       "wheel you cannot see; too big and every grip in a car grabs.");
                 }
                 float m = state.xrWheelSteerMaxDeg > 0.0f ? state.xrWheelSteerMaxDeg : 90.0f;
-                if (ImGui::SliderFloat("Full lock at (deg)", &m, 30.0f, 120.0f, "%.0f")) {
+                if (SliderFloatReset("Full lock at (deg)", &m, 30.0f, 120.0f, "%.0f", 90.0f)) {
                     state.xrWheelSteerMaxDeg = m;
                     changed = true;
                 }
@@ -761,7 +901,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                                       "Lower = the same wrist movement steers more.");
                 }
                 float d = state.xrWheelSteerDeadDeg >= 0.0f ? state.xrWheelSteerDeadDeg : 1.5f;
-                if (ImGui::SliderFloat("Steering deadzone (deg)", &d, 0.0f, 20.0f, "%.1f")) {
+                if (SliderFloatReset("Steering deadzone (deg)", &d, 0.0f, 20.0f, "%.1f", 1.5f)) {
                     state.xrWheelSteerDeadDeg = d;
                     changed = true;
                 }
@@ -781,7 +921,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                         "No grip needed; a hand that is GRABBING the wheel never honks.");
                 }
                 float hr = state.xrWheelHornRadius > 0.0f ? state.xrWheelHornRadius : 0.12f;
-                if (ImGui::SliderFloat("Horn hub radius (m)", &hr, 0.04f, 0.30f, "%.2f")) {
+                if (SliderFloatReset("Horn hub radius (m)", &hr, 0.04f, 0.30f, "%.2f", 0.12f)) {
                     state.xrWheelHornRadius = hr;
                     changed = true;
                 }
@@ -805,7 +945,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                         "trim: no lean / rock and no autodrive gesture until you holster.");
                 }
                 float tt = state.xrVehicleThrottleTrim > 0.0f ? state.xrVehicleThrottleTrim : 0.5f;
-                if (ImGui::SliderFloat("Throttle trim rate (/s)", &tt, 0.05f, 3.0f, "%.2f")) {
+                if (SliderFloatReset("Throttle trim rate (/s)", &tt, 0.05f, 3.0f, "%.2f", 0.5f)) {
                     state.xrVehicleThrottleTrim = tt;
                     changed = true;
                 }
@@ -861,7 +1001,7 @@ bool DrawLiveControls(LiveControlsUiState& state) {
                                   "instead of smooth rotation. Helps with motion sickness.");
             }
             if (state.xrSnapTurn != 0) {
-                changed |= ImGui::SliderFloat("Snap angle", &state.xrSnapTurnAngleDeg, 10.0f, 90.0f, "%.0f deg");
+                changed |= SliderFloatReset("Snap angle", &state.xrSnapTurnAngleDeg, 10.0f, 90.0f, "%.0f deg", 30.0f);
             }
 
             ImGui::Separator();

--- a/src/Runtimes/OpenXRManager.cpp
+++ b/src/Runtimes/OpenXRManager.cpp
@@ -1,4 +1,5 @@
 #include "Anim/WheelGrab.hpp"   // the wheel-grab blends, for the hand smoothing below
+#include "Core/LiveControls.hpp"
 #include "Runtimes/OpenXRManager.hpp"
 #include "Utils/SharedSlots.hpp"   // CyberpunkVR_Hands_Shared slot map (single source of truth)
 #include "Hooks/Ngx.hpp"
@@ -1472,6 +1473,77 @@ bool OpenXRManager::GetCurrentEyeFov(int eye, XrFovf* out) {
     if (!useSyncedViews && static_cast<size_t>(eye) >= m_views.size()) return false;
     *out = useSyncedViews ? m_syncedEyeFovs[eye] : m_views[eye].fov;
     return true;
+}
+
+float OpenXRManager::GetViewBoxManualSlideRad() {
+    const float deg = g_liveControls.xrViewBoxPitchDeg;
+    if (!(deg > -30.0f && deg < 30.0f)) return 0.0f;
+    if (std::fabs(deg) < 0.01f) return 0.0f;
+    return deg * (3.1415926535f / 180.0f);
+}
+
+float OpenXRManager::GetViewBoxManualYawRad() {
+    const float deg = g_liveControls.xrViewBoxYawDeg;
+    if (!(deg > -30.0f && deg < 30.0f)) return 0.0f;
+    if (std::fabs(deg) < 0.01f) return 0.0f;
+    return deg * (3.1415926535f / 180.0f);
+}
+
+float OpenXRManager::GetViewBoxPitchRad() {
+    float pitch = 0.0f;
+    if (g_liveControls.xrLensBoxCenter != 0) {
+        XrFovf left{}, right{};
+        if (GetCurrentEyeFov(0, &left) && GetCurrentEyeFov(1, &right)) {
+            pitch = GetLensVerticalCenterRad(left, right);
+        }
+    }
+    pitch += -GetViewBoxManualSlideRad();
+    if (!(pitch > -0.7f && pitch < 0.7f)) return 0.0f;
+    return pitch;
+}
+
+float OpenXRManager::GetViewBoxYawRad() {
+    float yaw = 0.0f;
+    if (g_liveControls.xrLensBoxCenter != 0) {
+        XrFovf left{}, right{};
+        if (GetCurrentEyeFov(0, &left) && GetCurrentEyeFov(1, &right)) {
+            yaw = GetLensHorizontalCenterRad(left, right);
+        }
+    }
+    yaw += -GetViewBoxManualYawRad();
+    if (!(yaw > -0.7f && yaw < 0.7f)) return 0.0f;
+    return yaw;
+}
+
+void OpenXRManager::ApplyViewBoxPitch(OpenXRHeadPose* pose) {
+    if (!pose || !pose->valid) return;
+    const float pitch = GetViewBoxPitchRad();
+    const float yaw = GetViewBoxYawRad();
+    if (std::fabs(pitch) < 1.0e-5f && std::fabs(yaw) < 1.0e-5f) return;
+
+    XrQuaternionf q = { pose->oriX, pose->oriY, pose->oriZ, pose->oriW };
+    if (std::fabs(yaw) >= 1.0e-5f) {
+        const float half = yaw * 0.5f;
+        const XrQuaternionf qYaw{ 0.0f, std::sinf(half), 0.0f, std::cosf(half) };
+        q = MultiplyQuat(q, qYaw);
+    }
+    if (std::fabs(pitch) >= 1.0e-5f) {
+        const float half = pitch * 0.5f;
+        const XrQuaternionf qPitch{ std::sinf(half), 0.0f, 0.0f, std::cosf(half) };
+        q = MultiplyQuat(q, qPitch);
+    }
+    pose->oriX = q.x;
+    pose->oriY = q.y;
+    pose->oriZ = q.z;
+    pose->oriW = q.w;
+    static bool s_logged = false;
+    if (!s_logged) {
+        s_logged = true;
+        Log("OpenXRManager[VIEWBOX]: pitch=%.3f yaw=%.3f deg on camera+submit "
+            "(no FOV change; Center box + Box-down/right)\n",
+            pitch * (180.0f / 3.1415926535f),
+            yaw * (180.0f / 3.1415926535f));
+    }
 }
 
 void OpenXRManager::StoreRenderEyePose(int eye, const OpenXRHeadPose& pose, uint32_t seq) {


### PR DESCRIPTION
## Summary

This PR adds an **opt-in "Center box on lens"** correction for canted-headset optics, improves the **F10 overlay** with per-slider reset buttons and keyboard left/right adjustment, and fixes a **runtime FOV toggle** regression where unchecking "Use OpenXR runtime projection FOV" always snapped back to 112° instead of the user's previous manual value.

No change to the existing panel-covering FOV path (`GetPanelCoveringHorizontalFovDeg`); the new feature rotates **pose only** (render camera + OpenXR submit label together), so FOV and pixel density are unchanged.

---

## Motivation

### 1. Canted optics vs. symmetric render (Quest 3 and similar)

The port already handles canted panels by sizing the game frustum to **cover** the panel (`GetPanelCoveringHorizontalFovDeg`, PR #24). That removes black borders but leaves the **picture box centered on the HMD forward axis**, not on each lens's **optical centre**.

On Quest 3-class hardware the runtime reports asymmetric per-eye frusta (e.g. vertically ~+44° / −55°, i.e. optical centre ~5.5° below head-forward). With a symmetric engine frustum centred on head-forward, users see the classic symptom: clipped top, visible bottom edge, image feels shifted in the headset even after FOV cover is correct.

`ComputeRuntimeFovCorrection()` recentres frustum *numbers* onto the eye axis, but the engine still renders a **symmetric** frustum with **no off-axis shear** — so the missing piece is rotating the **view/submit pose** to match where the lens actually looks, without widening FOV again.

Comments in `RuntimeFovCorrection.hpp` already describe this gap explicitly ("nothing rotates the POSE to match"). This PR fills that gap for users who want it.

### 2. Why default **off**

Not all users run Quest 3 / canted optics (Index, Pico 4, etc. report near-zero optical offset). Auto-applying a pitch/yaw correction on every headset would be a silent behaviour change. The feature is therefore **opt-in** via F10 and `xr_lens_box_center=0` in fresh `vrport.ini`.

### 3. F10 usability (keyboard + reset)

VR users often navigate F10 with keyboard (up/down to focus, but ImGui's built-in slider keyboard tweak was not giving predictable 0.1 steps in practice). Sliders also lacked a quick way to return to shipped defaults without hand-editing `vrport.ini`.

### 4. Runtime FOV toggle bug

When enabling "Use OpenXR runtime projection FOV", the manual FOV slider is disabled and displays 112° (placeholder). On disable, the code previously wrote `xrForceFov = 112`, discarding e.g. a user-tuned 86°. Users expect the last manual value to return.

---

## What changed

### A. Center box on lens (opt-in)

**UI (F10 → General → Tracking / Camera → HMD picture box)**

| Control | `vrport.ini` key | Default |
|--------|------------------|---------|
| Center box on lens | `xr_lens_box_center` | `0` (off) |
| Box vertical (deg) | `xr_view_box_pitch_deg` | `0` (+ = down, − = up) |
| Box horizontal (deg) | `xr_view_box_yaw_deg` | `0` (+ = right, − = left) |

**Optical centre from runtime FOV**

Added helpers in `RuntimeFovCorrection.hpp`:

- `GetLensVerticalCenterRad(left, right)` — average of four vertical half-angles across both eyes  
- `GetLensHorizontalCenterRad(left, right)` — same for horizontal (often ~0 on Quest 3 due to opposing eye cant)

**Pose rotation (no FOV change)**

`OpenXRManager::GetViewBoxPitchRad()` / `GetViewBoxYawRad()`:

- If `xr_lens_box_center` is set, add runtime-derived pitch/yaw  
- Add negated manual offsets from the F10 sliders  
- Clamp to ±0.7 rad; invalid → 0  

`ApplyViewBoxPitch()` applies local yaw (Y) then pitch (X) to the head quaternion only.

**Applied in both places that must agree**

- `LocateCamera.cpp` — render camera path  
- `PatchCamera.cpp` — compose-at-write path  

Same pose is pushed to `PushRenderHeadPose()` so the compositor timewarp label matches pixels. Rotating only one side would cause reprojection judder or offset snapping.

**Persistence**

- `LiveControlsPoll.cpp` / `LauncherConfig.cpp` / `EnsureLiveControlFileExists()` round-trip the three keys; defaults are 0.

---

### B. F10 slider reset + keyboard tweak

- New `SliderFloatReset()` wrapper in `OverlayPanels.cpp`:
  - ReShade-style circular-arrow reset button to the right of each slider (resets to the same default the mod uses on first launch / missing ini key)
  - Left/right arrow (and D-pad) adjusts focused slider by **0.1** per key repeat; cancels nav move so focus does not jump away
  - Reset button uses `ImGuiItemFlags_NoNav` so it does not steal arrow-key focus

Applied to all F10 float sliders (General, Tracking/Camera, Controls, VRIK calibration, diagnostics telemetry, etc.).

---

### C. Runtime FOV toggle restore

`DrawFovControl()` keeps a session `s_savedManualFov`:

- Updated whenever `xrForceFov > 0`  
- Saved before switching to runtime mode (`xrForceFov = 0`)  
- Restored when unchecking runtime FOV; falls back to 112 only if no manual value was ever set  

Slider edits while in manual mode do not apply when runtime mode is active (disabled UI).

---

## Files touched

| Area | Files |
|------|--------|
| Lens centre math | `include/Runtimes/RuntimeFovCorrection.hpp` |
| Pose apply | `src/Runtimes/OpenXRManager.cpp`, `include/Runtimes/OpenXRManager.hpp` |
| Camera hooks | `src/Hooks/LocateCamera.cpp`, `src/Hooks/PatchCamera.cpp` |
| Live settings | `include/Core/LiveControls.hpp`, `include/Overlay/LiveControlsUi.hpp`, `src/Core/LiveControlsPoll.cpp`, `src/Core/LauncherConfig.cpp` |
| F10 UI | `src/Overlay/OverlayPanels.cpp` |

---

## Behaviour notes for reviewers

- **Symmetric HMDs:** With `xr_lens_box_center=0`, runtime-derived offsets are skipped; manual sliders still work. On symmetric frusta, auto pitch/yaw ≈ 0 anyway.  
- **FOV unchanged:** Unlike panel-cover, this does not alter `xr_force_fov` or horizontal FOV scalar; only orientation.  
- **Quest 3 horizontal auto:** Often near zero; horizontal fine-tune is mainly for manual slider / per-runtime quirks.  
- **Separate from head offsets:** `xr_head_offset_*` translate the view in metres; view box rotates the picture box.  

---

## Screenshots / hardware

_(Optional: add before/after headset photos on Quest 3 if you have them.)_

Tested build: Release `CyberpunkVR_Stereo.dll` on Windows, OpenXR runtime as used in daily play.

---

## Related context

Complements existing canted-panel handling (panel-cover FOV, `ComputeRuntimeFovCorrection` comments). Does not replace it — addresses **centre alignment** rather than **edge coverage**.